### PR TITLE
cli: EXPLAIN queries, add interactive mode

### DIFF
--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -36,6 +36,7 @@ DATE_FORMAT = "%H:%M:%S"
 @click.option("-s", "--stats", is_flag=True, help="Print stats instead of a detailed diff")
 @click.option("-d", "--debug", is_flag=True, help="Print debug info")
 @click.option("-v", "--verbose", is_flag=True, help="Print extra info")
+@click.option('-i', '--interactive', is_flag=True, help='Confirm queries, implies --debug')
 def main(
     db1_uri,
     table1_name,
@@ -52,10 +53,13 @@ def main(
     stats,
     debug,
     verbose,
+    interactive,
 ):
     if limit and stats:
         print("Error: cannot specify a limit when using the -s/--stats switch")
         return
+    if interactive:
+        debug = True
 
     if debug:
         logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT, datefmt=DATE_FORMAT)
@@ -64,6 +68,10 @@ def main(
 
     db1 = connect_to_uri(db1_uri)
     db2 = connect_to_uri(db2_uri)
+
+    if interactive:
+        db1.enable_interactive()
+        db2.enable_interactive()
 
     start = time.time()
 

--- a/data_diff/sql.py
+++ b/data_diff/sql.py
@@ -133,6 +133,7 @@ class In(Sql):
         return f"({c.compile(self.expr)} IN ({elems}))"
 
 
+
 @dataclass
 class Count(Sql):
     column: Optional[SqlOrStr] = None
@@ -146,6 +147,18 @@ class Count(Sql):
 @dataclass
 class Time(Sql):
     time: datetime
+    column: Optional[SqlOrStr] = None
 
     def compile(self, c: Compiler):
         return "'%s'" % self.time.isoformat()
+        if self.column:
+            return f"count({c.compile(self.column)})"
+        return 'count(*)'
+
+
+@dataclass
+class Explain(Sql):
+    sql: Select
+
+    def compile(self, c: Compiler):
+        return f"EXPLAIN {c.compile(self.sql)}"

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,7 +1,8 @@
 import unittest
 
 from data_diff.database import connect_to_uri
-from data_diff.sql import Checksum, Compare, Compiler, Enum, In, Select, TableName, Count
+from data_diff.sql import (Checksum, Compare, Compiler, Count, Enum, Explain, In,
+                       Select, TableName)
 
 from .common import TEST_MYSQL_CONN_STRING
 
@@ -90,4 +91,14 @@ class TestSQL(unittest.TestCase):
             self.compiler.compile(
                 Select([Count("id")], TableName(("marine_mammals", "walrus")), [In("id", [1, 2, 3])])
             ),
+        )
+
+    def test_explain(self):
+        expected_sql = "EXPLAIN SELECT count(id) FROM `marine_mammals.walrus` WHERE (id IN (1, 2, 3))"
+        self.assertEqual(expected_sql, self.compiler.compile(
+            Explain(Select(
+                [Count("id")],
+                TableName(("marine_mammals", "walrus")),
+                [In("id", [1, 2, 3])]
+            )))
         )


### PR DESCRIPTION
When running this with real customers, it'll be very useful to:

* `EXPLAIN` every query in debug-mode to the debug log
* Add an `--interactive` mode that causes you to confirm after every query + explain has been listed, to ensure we don't e.g. run a full-table scan on a massive table