### PR TITLE
threading: default to 1 thread

### DIFF
--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -44,7 +44,7 @@ COLOR_SCHEME = {
 @click.option("-v", "--verbose", is_flag=True, help="Print extra info")
 @click.option("-i", "--interactive", is_flag=True, help="Confirm queries, implies --debug")
 @click.option(
-    "-j", "--threads", default=None, help="Number of threads to use. 1 means no threading. Auto if not specified."
+    "-j", "--threads", default='1', help="Number of threads to use. Default of 1 means no threading."
 )
 def main(
     db1_uri,
@@ -77,10 +77,13 @@ def main(
         logging.basicConfig(level=logging.INFO, format=LOG_FORMAT, datefmt=DATE_FORMAT)
 
     if threads is not None:
-        threads = int(threads)
-        if threads < 1:
-            logging.error("Error: threads must be >= 1")
-            return
+        if threads.lower() == 'auto':
+            threads = None
+        else:
+            threads = int(threads)
+            if threads < 1:
+                logging.error("Error: threads must be >= 1")
+                return
 
     db1 = connect_to_uri(db1_uri, threads)
     db2 = connect_to_uri(db2_uri, threads)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         -c maintenance_work_mem=1GB
         -c max_wal_size=8GB
       restart: always
-      volumes: 
+      volumes:
         - postgresql-data:/var/lib/postgresql/data:delegated
       ports:
         - '5432:5432'
@@ -32,13 +32,13 @@ services:
         --default-authentication-plugin=mysql_native_password
         --binlog-cache-size=16M
         --key_buffer_size=0
-        --max_connections=10
+        --max_connections=1000
         --innodb_flush_log_at_trx_commit=2
         --innodb_flush_log_at_timeout=10
         --innodb_log_compressed_pages=OFF
         --sync_binlog=0
       restart: always
-      volumes: 
+      volumes:
         - mysql-data:/var/lib/mysql:delegated
       user: mysql
       ports:


### PR DESCRIPTION
* Change to 1 thread by default, as this is less dangerous of a default on e.g. a Postgres
* Change to 1000 connections to MySQL in `docker-compose` as we can now use _way_ more than 10 connections to MySQL