### PR TITLE
Initial code to canonize fields; reads and parses schema. [WIP]

### DIFF
--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -19,8 +19,10 @@ COLOR_SCHEME = {
     "-": "red",
 }
 
+
 def parse_table_name(t):
-    return tuple(t.split('.'))
+    return tuple(t.split("."))
+
 
 @click.command()
 @click.argument("db1_uri")

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -246,8 +246,7 @@ class TableDiffer:
 
     def _diff_tables(self, table1, table2, level=0, segment_index=None, segment_count=None):
         logger.info(
-            ". " * level
-            + f"Diffing segment {segment_index}/{segment_count}, "
+            ". " * level + f"Diffing segment {segment_index}/{segment_count}, "
             f"key-range: {table1.start_key}..{table2.end_key}, "
             f"size: {table2.end_key-table1.start_key}"
         )

--- a/data_diff/sql.py
+++ b/data_diff/sql.py
@@ -97,7 +97,7 @@ class Enum(Sql):
     order_by: SqlOrStr
 
     def compile(self, c: Compiler):
-        table =  ".".join(map(c.quote, self.table))
+        table = ".".join(map(c.quote, self.table))
         order = c.compile(self.order_by)
         return f"(SELECT *, (row_number() over (ORDER BY {order})) as idx FROM {table} ORDER BY {order}) tmp"
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,16 +1,26 @@
 import hashlib
 
-from data_diff.database import CHECKSUM_HEXDIGITS, MD5_HEXDIGITS
+from data_diff import database as db
 import logging
 
 logging.basicConfig(level=logging.WARN)
 
-TEST_MYSQL_CONN_STRING = "mysql://mysql:Password1@localhost/mysql"
+TEST_MYSQL_CONN_STRING: str = None
+TEST_POSTGRES_CONN_STRING: str = None
+TEST_SNOWFLAKE_CONN_STRING: str = None
 
 try:
     from .local_settings import *
 except ImportError:
     pass  # No local settings
+
+assert TEST_MYSQL_CONN_STRING and TEST_POSTGRES_CONN_STRING and TEST_SNOWFLAKE_CONN_STRING
+
+CONN_STRINGS = {
+    db.MySQL: TEST_MYSQL_CONN_STRING,
+    db.Postgres: TEST_POSTGRES_CONN_STRING,
+    db.Snowflake: TEST_SNOWFLAKE_CONN_STRING,
+}
 
 
 def str_to_checksum(str: str):
@@ -22,5 +32,5 @@ def str_to_checksum(str: str):
     m.update(str.encode("utf-8"))  # encode to binary
     md5 = m.hexdigest()
     # 0-indexed, unlike DBs which are 1-indexed here, so +1 in dbs
-    half_pos = MD5_HEXDIGITS - CHECKSUM_HEXDIGITS
+    half_pos = db.MD5_HEXDIGITS - db.CHECKSUM_HEXDIGITS
     return int(md5[half_pos:], 16)

--- a/tests/test_canonize.py
+++ b/tests/test_canonize.py
@@ -1,0 +1,89 @@
+import unittest
+from datetime import datetime, timezone
+
+import preql
+
+from data_diff.database import MySQL, Snowflake, connect_to_uri
+from data_diff.sql import Select
+from data_diff import database as db
+
+from .common import CONN_STRINGS
+
+
+DATE_TYPES = {
+    db.Postgres: ["timestamp(6) with time zone", "timestamp(6) without time zone"],
+    db.MySQL: ["datetime(6)", "timestamp(6)"],
+    db.Snowflake: ["timestamp(6)", "timestamp_tz(6)", "timestamp_ntz(6)"],
+    db.BigQuery: ["timestamp(6)", "datetime(6)"],
+    db.Redshift: ["timestamp(6)", "timestampz(6)"],
+    db.Oracle: ["timestamp(n) with timezone", "timestamp(n) with local time zone"],
+    db.Presto: ["timestamp", "timestamp with zone"],
+}
+
+
+class TestCanonize(unittest.TestCase):
+    i = 0
+
+    def _new_table(self, name):
+        self.i += 1
+        return f"t_{self.i}"
+
+    def test_canonize(self):
+        all_returned = {}
+
+        for db_id, conn_string in CONN_STRINGS.items():
+
+            sample_date1 = datetime(2022, 6, 3, 12, 24, 35, 69296)
+            sample_date2 = datetime(2021, 5, 2, 11, 23, 34, 58185, tzinfo=timezone.utc)
+            if db_id is MySQL:
+                # TODO Issue when adding timezone to mysql
+                dates = [sample_date1, sample_date2.replace(tzinfo=None)]
+            else:
+                dates = [sample_date1, sample_date2]
+
+            pql = preql.Preql(conn_string)
+
+            date_type_tables = {dt: self._new_table(dt) for dt in DATE_TYPES[db_id]}
+            used_tables = list(date_type_tables.values())
+            conn = None
+            try:
+                for date_type, table in date_type_tables.items():
+                    pql.run_statement(f"DROP TABLE IF EXISTS {table}")
+                    pql.run_statement(f"CREATE TABLE {table}(v {date_type})")
+                pql.run_statement(f"COMMIT")
+
+                for date_type, table in date_type_tables.items():
+
+                    for date in dates:
+                        # print(f"insert into {table}(v) values ('{date}')")
+                        pql.run_statement(f"insert into {table}(v) values ('{date}')")
+                pql.run_statement(f"COMMIT")
+
+                conn = connect_to_uri(conn_string)
+                assert type(conn) is db_id  # Might change in the future
+                if db_id is Snowflake:
+                    conn.query("alter session set timestamp_output_format = 'YYYY-MM-DD HH24:MI:SS.FF6TZH'", None)
+                    conn.query("alter session set timestamp_ntz_output_format = 'YYYY-MM-DD HH24:MI:SS.FF6'", None)
+
+                for date_type, table in date_type_tables.items():
+                    schema = conn.query_table_schema((table,))
+
+                    returned_dates = tuple(
+                        x for x, in conn.query(Select([conn.canonize_by_type("v", schema["v"])], table), list)
+                    )
+
+                    # print("@@", db_id, date_type, " --> ", returned_dates)
+                    all_returned[db_id, date_type] = returned_dates
+
+            finally:
+                if conn:
+                    conn.close()
+                for t in used_tables:
+                    try:
+                        pql.run_statement(f"DROP TABLE {t}")
+                    except preql.Signal:
+                        pass
+
+        all_reprs = set(all_returned.values())
+        # print("@@", all_reprs)
+        assert len(all_reprs) == 1


### PR DESCRIPTION
The field canonization problem can be split into two:

1) The SQL representation of fields is different between databases, and even within the same database for variations on the same type (precision, timezone).

2) When querying the database, some libraries return different Python types (like `datetime.time` vs `timedelta`)

Given that we can solve (1), it's easy to solve (2) by always downloading canonized strings and diffing them, instead of native Python objects like `datetime`.

Unfortunately, the only way to solve (1) is to know the type of the column, and that requires querying the schema for each table.

This PR starts by implementing and testing the necessary helper functions for Postgres, Mysql and Snowflake.

Open questions:
- What about timezones? What if they are different between databases? should they appear in the repr?