### PR TITLE
Update snowflake URIto align with SQLAlchemy

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ data-diff \
 |---------------|-----------------------------------------------------------------------------------------|--------|
 | Postgres      | `postgres://user:password@hostname:5432/database`                                       |  💚    |
 | MySQL         | `mysql://user:password@hostname:5432/database`                                          |  💚    |
-| Snowflake     | `snowflake://user:password@account/warehouse?database=database&schema=schema&role=role` |  💚    |
+| Snowflake     | `snowflake://user:password@account/database/schema?warehouse=warehouse&role=role`       |  💚    |
 | Oracle        | `oracle://username:password@hostname/database`                                          |  💛    |
 | BigQuery      | `bigquery:///`                                                                          |  💛    |
 | Redshift      | `redshift://username:password@hostname:5439/database`                                   |  💛    |


### PR DESCRIPTION
New format: `snowflake://<user>:<pass>@<account>/<database>/<schema>?warehouse=<warehouse>` 

Example: `snowflake://user:pass@account/xdiffdev/test1?warehouse=INTEGRATION`

I think our URI made more sense before, but sometimes backwards-compatibility trumps common sense.