### PR TITLE
Fix for BigQuery: Table-name no longer needs dataset, takes it from URI

### DIFF
--- a/data_diff/sql.py
+++ b/data_diff/sql.py
@@ -46,7 +46,8 @@ class TableName(Sql):
     name: DbPath
 
     def compile(self, c: Compiler):
-        return ".".join(map(c.quote, self.name))
+        path = c.database._normalize_table_path(self.name)
+        return ".".join(map(c.quote, path))
 
 
 @dataclass


### PR DESCRIPTION
Now we can run:

data_diff bigquery://datafold-dev-2/data_diff rating bigquery://datafold-dev-2/data_diff rating_del1