### PR TITLE
tests: fix presto, add faker classes

### DIFF
--- a/data_diff/databases/presto.py
+++ b/data_diff/databases/presto.py
@@ -50,7 +50,13 @@ class Presto(Database):
 
     def _query(self, sql_code: str) -> list:
         "Uses the standard SQL cursor interface"
-        return _query_conn(self._conn, sql_code)
+        c = self._conn.cursor()
+        c.execute(sql_code)
+        if sql_code.lower().startswith("select"):
+            return c.fetchall()
+        # Required for the query to actually run 🤯
+        if re.match(r"(insert|create|truncate|drop)", sql_code, re.IGNORECASE):
+            return c.fetchone()
 
     def close(self):
         self._conn.close()

--- a/data_diff/databases/presto.py
+++ b/data_diff/databases/presto.py
@@ -94,7 +94,7 @@ class Presto(Database):
                 datetime_precision = int(m.group(1))
                 return cls(
                     precision=datetime_precision if datetime_precision is not None else DEFAULT_DATETIME_PRECISION,
-                    rounds=False,
+                    rounds=self.ROUNDS_ON_PREC_LOSS,
                 )
 
         number_regexps = {r"decimal\((\d+),(\d+)\)": Decimal}

--- a/dev/presto-conf/standalone/catalog/postgresql.properties
+++ b/dev/presto-conf/standalone/catalog/postgresql.properties
@@ -2,3 +2,4 @@ connector.name=postgresql
 connection-url=jdbc:postgresql://postgres:5432/postgres
 connection-user=postgres
 connection-password=Password1
+allow-drop-table=true

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,9 +1,8 @@
 import hashlib
+import os
 
 from data_diff import databases as db
 import logging
-
-logging.basicConfig(level=logging.INFO)
 
 TEST_MYSQL_CONN_STRING: str = "mysql://mysql:Password1@localhost/mysql"
 TEST_POSTGRESQL_CONN_STRING: str = None
@@ -13,6 +12,16 @@ TEST_REDSHIFT_CONN_STRING: str = None
 TEST_ORACLE_CONN_STRING: str = None
 TEST_PRESTO_CONN_STRING: str = None
 
+DEFAULT_N_SAMPLES = 50
+N_SAMPLES = int(os.environ.get("N_SAMPLES", DEFAULT_N_SAMPLES))
+
+level = logging.ERROR
+if os.environ.get("LOG_LEVEL", False):
+    level = getattr(logging, os.environ["LOG_LEVEL"].upper())
+
+logging.basicConfig(level=level)
+logging.getLogger("diff_tables").setLevel(level)
+logging.getLogger("database").setLevel(level)
 
 try:
     from .local_settings import *


### PR DESCRIPTION
First set of changes to allow the test suites to be used for benchmarking:

1. _Actually_ use Presto for inserting/etc., before it was just using the backing Postgres table I think, because it wasn't working properly for me (and fix some Presto related bugs)
2. Add `*Faker` classes that are capable of producing an infinite amount of rows for benchmarking
3. Add pagination for the import into the destination table, required when we do millions of rows
4. Fix Presto rounding (I think this is supporting of (1) that it wasn't tested the way we thought?)
5. Add a few more things to make the test and table names nicer

Just trying to split this up so it's easier to review