### PR TITLE
Set author to Datafold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "data-diff"
 version = "0.2.1"
 description = "Command-line tool and Python library to efficiently diff rows across two different databases."
-authors = ["Erez Shinnan <erezshin@gmail.com>", "Simon Eskildsen <simon@sirupsen.com>"]
+authors = ["Datafold <data-diff@datafold.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/datafold/data-diff"


### PR DESCRIPTION
Setting author to Datafold team alias to make sure all inquiries are routed to designated team members and handled appropriately.