### PR TITLE
benchmark: add suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ ml-25m*
 ratings*.csv
 drive
 mysqltuner.pl
+benchmark_*.jsonl
 
 # Mac
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -457,6 +457,13 @@ $ poetry run preql -f dev/prepare_db.pql bigquery:///<project>
 poetry run python3 -m data_diff postgresql://postgres:Password1@localhost/postgres rating postgresql://postgres:Password1@localhost/postgres rating_del1 --verbose
 ```
 
+**6. Run benchmarks (optional)**
+
+```shell-session
+$ dev/benchmark.sh
+```
+
+
 # License
 
 [MIT License](https://github.com/datafold/data-diff/blob/master/LICENSE)

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,6 +3,7 @@ import os
 
 from data_diff import databases as db
 import logging
+import subprocess
 
 TEST_MYSQL_CONN_STRING: str = "mysql://mysql:Password1@localhost/mysql"
 TEST_POSTGRESQL_CONN_STRING: str = None
@@ -14,6 +15,12 @@ TEST_PRESTO_CONN_STRING: str = None
 
 DEFAULT_N_SAMPLES = 50
 N_SAMPLES = int(os.environ.get("N_SAMPLES", DEFAULT_N_SAMPLES))
+BENCHMARK = os.environ.get("BENCHMARK", False)
+
+def get_git_revision_short_hash() -> str:
+    return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+
+GIT_REVISION=get_git_revision_short_hash()
 
 level = logging.ERROR
 if os.environ.get("LOG_LEVEL", False):


### PR DESCRIPTION
Cleanup of resolved merge conflict from https://github.com/datafold/data-diff/pull/67 based on all the changes in master. Trying to split it up into chunks to make it easier to review (and do an extra pass on it all)

The idea is to dual-purpose a subset of the type test-suite for benchmarking, to ensure it doesn't rust. In particular, to follow-up from https://github.com/datafold/data-diff/pull/106, the changes are to:

* In `BENCHMARK=1` mode, we do not want to drop tables, to prevent waiting for millions of rows to be inserted again. Not even across revisions if we're testing the performance change between two revisions
* Create indexes, to have good performance
* Write benchmark results to stdout and JSONL file(s) for graphing/analysis after
* Insert in larger batches for performance (follow-up on CSV)
* When benchmarking, we want to download segments in parallel for fairness

There are plenty of follow-ups to this, likely not all of which I will be able to complete:

* Enable threading > 1 in the test suite, which likely leads to some connection pooling logic changes I'd rather do parallel
* Do CSV insertion for the Cloud databases, to make it much faster to reproduce tests for 100M rows (currently takes hours)
* Add steps on how to reproduce the graph in the README based on `benchmark_*.jsonl`
* Add benchmarks with an increasing % of changed/deleted rows

@erezsh 

cc @abhinav1912 due to questions in https://github.com/datafold/data-diff/issues/103