### PR TITLE
tests: add bigint/int

### DIFF
--- a/data_diff/databases/mysql.py
+++ b/data_diff/databases/mysql.py
@@ -20,6 +20,7 @@ class MySQL(ThreadedDatabase):
         "float": Float,
         "decimal": Decimal,
         "int": Integer,
+        "bigint": Integer,
     }
     ROUNDS_ON_PREC_LOSS = True
 

--- a/tests/test_database_types.py
+++ b/tests/test_database_types.py
@@ -264,7 +264,6 @@ DATABASE_TYPES = {
     db.Oracle: {
         "int": [
             "int",
-            "bigint",
         ],
         "datetime_no_timezone": [
             "timestamp with local time zone",

--- a/tests/test_database_types.py
+++ b/tests/test_database_types.py
@@ -170,7 +170,7 @@ DATABASE_TYPES = {
         "int": [
             # "smallint",  # 2 bytes
             "int",  # 4 bytes
-            # "bigint", # 8 bytes
+            "bigint", # 8 bytes
         ],
         # https://www.postgresql.org/docs/current/datatype-datetime.html
         "datetime_no_timezone": [
@@ -193,7 +193,7 @@ DATABASE_TYPES = {
             # "smallint", # 2 bytes
             # "mediumint", # 3 bytes
             "int",  # 4 bytes
-            # "bigint", # 8 bytes
+            "bigint", # 8 bytes
         ],
         # https://dev.mysql.com/doc/refman/8.0/en/datetime.html
         "datetime_no_timezone": [
@@ -228,8 +228,8 @@ DATABASE_TYPES = {
         "int": [
             # all 38 digits with 0 precision, don't need to test all
             "int",
-            # "integer",
-            # "bigint",
+            "integer",
+            "bigint",
             # "smallint",
             # "tinyint",
             # "byteint"
@@ -264,6 +264,7 @@ DATABASE_TYPES = {
     db.Oracle: {
         "int": [
             "int",
+            "bigint",
         ],
         "datetime_no_timezone": [
             "timestamp with local time zone",
@@ -281,7 +282,7 @@ DATABASE_TYPES = {
             # "smallint", # 2 bytes
             # "mediumint", # 3 bytes
             "int",  # 4 bytes
-            # "bigint", # 8 bytes
+            "bigint", # 8 bytes
         ],
         "datetime_no_timezone": [
             "timestamp",


### PR DESCRIPTION
@erezsh some more goodies for you: A bunch of `int` / `bigint` tests fail.

Run this branch with `poetry run unittest-parallel -j 64 -k int` to reproduce.

Example error:

```
======================================================================
test_types_redshift_int_to_mysql_bigint_50 (tests.test_database_types.TestDiffCrossDatabaseTables)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/.cache/pypoetry/virtualenvs/data-diff-yPhKwkIo-py3.10/lib/python3.10/site-packages/parameterized/parameterized.py", line 533, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "/root/data-diff/tests/test_database_types.py", line 443, in test_types
    diff = list(differ.diff_tables(self.table, self.table2))
  File "/root/data-diff/data_diff/diff_tables.py", line 295, in diff_tables
    self._validate_and_adjust_columns(table1, table2)
  File "/root/data-diff/data_diff/diff_tables.py", line 339, in _validate_and_adjust_columns
    raise TypeError(f"Incompatible types for column {c}:  {col1} <-> {col2}")
TypeError: Incompatible types for column col:  Integer(precision=0) <-> UnknownColType(text='bigint')
```