### PR TITLE
Added support for compound key 

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ may be case-sensitive. This is the case for the Snowflake schema and table names
 Options:
 
   - `--help` - Show help message and exit.
-  - `-k` or `--key-column` - Name of the primary key column
+  - `-k` or `--key-column` - Name of primary key column. Default='id'. Can be given multiple times for a compound key. e.g. `-k id -k id2`.
   - `-t` or `--update-column` - Name of updated_at/last_updated column
   - `-c` or `--columns` - List of names of extra columns to compare
   - `-l` or `--limit` - Maximum number of differences to find (limits maximum bandwidth and runtime)

--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -15,7 +15,7 @@ from .diff_tables import (
 def connect_to_table(
     db_info: Union[str, dict],
     table_name: Union[DbPath, str],
-    key_columns: Tuple[str, ...] = ("id",),
+    key_columns: Union[str, Tuple[str, ...]] = "id",
     thread_count: Optional[int] = 1,
     **kwargs,
 ):
@@ -32,6 +32,9 @@ def connect_to_table(
 
     if isinstance(table_name, str):
         table_name = db.parse_table_name(table_name)
+
+    if isinstance(key_columns, str):
+        key_columns = (key_columns,)
 
     return TableSegment(db, table_name, key_columns, **kwargs)
 

--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -13,7 +13,11 @@ from .diff_tables import (
 
 
 def connect_to_table(
-    db_info: Union[str, dict], table_name: Union[DbPath, str], key_column: str = "id", thread_count: Optional[int] = 1, **kwargs
+    db_info: Union[str, dict],
+    table_name: Union[DbPath, str],
+    key_columns: Tuple[str, ...] = ("id",),
+    thread_count: Optional[int] = 1,
+    **kwargs,
 ):
     """Connects to the given database, and creates a TableSegment instance
 
@@ -29,7 +33,7 @@ def connect_to_table(
     if isinstance(table_name, str):
         table_name = db.parse_table_name(table_name)
 
-    return TableSegment(db, table_name, key_column, **kwargs)
+    return TableSegment(db, table_name, key_columns, **kwargs)
 
 
 def diff_tables(
@@ -37,7 +41,7 @@ def diff_tables(
     table2: TableSegment,
     *,
     # Name of the key column, which uniquely identifies each row (usually id)
-    key_column: str = "id",
+    key_columns: Tuple[str, ...] = ("id",),
     # Name of updated column, which signals that rows changed (usually updated_at or last_update)
     update_column: str = None,
     # Extra columns to compare
@@ -71,7 +75,7 @@ def diff_tables(
     tables = [table1, table2]
     segments = [
         t.new(
-            key_column=key_column,
+            key_columns=key_columns,
             update_column=update_column,
             extra_columns=extra_columns,
             min_key=min_key,

--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -49,7 +49,7 @@ def diff_tables(
     update_column: str = None,
     # Extra columns to compare
     extra_columns: Tuple[str, ...] = (),
-    # Start/end key_column values, used to restrict the segment
+    # Start/end key values, used to restrict the segment.
     min_key: DbKey = None,
     max_key: DbKey = None,
     # Start/end update_column values, used to restrict the segment

--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -26,10 +26,11 @@ COLOR_SCHEME = {
     "-": "red",
 }
 
+
 def _remove_passwords_in_dict(d: dict):
     for k, v in d.items():
-        if k == 'password':
-            d[k] = '*' * len(v)
+        if k == "password":
+            d[k] = "*" * len(v)
         elif isinstance(v, dict):
             _remove_passwords_in_dict(v)
 
@@ -129,7 +130,7 @@ def _main(
         logging.error("Cannot specify a limit when using the -s/--stats switch")
         return
 
-    key_column = key_column or "id"
+    key_column = key_column or ("id",)
     if bisection_factor is None:
         bisection_factor = DEFAULT_BISECTION_FACTOR
     if bisection_threshold is None:
@@ -171,8 +172,8 @@ def _main(
         logging.error("Error while parsing age expression: %s" % e)
         return
 
-    table1_seg = TableSegment(db1, db1.parse_table_name(table1), key_column, update_column, columns, **options)
-    table2_seg = TableSegment(db2, db2.parse_table_name(table2), key_column, update_column, columns, **options)
+    table1_seg = TableSegment(db1, db1.parse_table_name(table1), (key_column,), update_column, columns, **options)
+    table2_seg = TableSegment(db2, db2.parse_table_name(table2), (key_column,), update_column, columns, **options)
 
     differ = TableDiffer(
         bisection_factor=bisection_factor,

--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -40,9 +40,9 @@ def _remove_passwords_in_dict(d: dict):
 @click.argument("table1", required=False)
 @click.argument("database2", required=False)
 @click.argument("table2", required=False)
-@click.option("-k", "--key-column", default=None, help="Name of primary key column. Default='id'.")
+@click.option("-k", "--key-column", multiple=True, help="Names of primary key columns. Default='id'.")
 @click.option("-t", "--update-column", default=None, help="Name of updated_at/last_updated column")
-@click.option("-c", "--columns", default=[], multiple=True, help="Names of extra columns to compare")
+@click.option("-c", "--columns", multiple=True, help="Names of extra columns to compare")
 @click.option("-l", "--limit", default=None, help="Maximum number of differences to find")
 @click.option("--bisection-factor", default=None, help=f"Segments per iteration. Default={DEFAULT_BISECTION_FACTOR}.")
 @click.option(
@@ -130,7 +130,7 @@ def _main(
         logging.error("Cannot specify a limit when using the -s/--stats switch")
         return
 
-    key_column = key_column or ("id",)
+    key_columns = tuple(key_column) or ("id",)
     if bisection_factor is None:
         bisection_factor = DEFAULT_BISECTION_FACTOR
     if bisection_threshold is None:
@@ -172,8 +172,8 @@ def _main(
         logging.error("Error while parsing age expression: %s" % e)
         return
 
-    table1_seg = TableSegment(db1, db1.parse_table_name(table1), (key_column,), update_column, columns, **options)
-    table2_seg = TableSegment(db2, db2.parse_table_name(table2), (key_column,), update_column, columns, **options)
+    table1_seg = TableSegment(db1, db1.parse_table_name(table1), key_columns, update_column, columns, **options)
+    table2_seg = TableSegment(db2, db2.parse_table_name(table2), key_columns, update_column, columns, **options)
 
     differ = TableDiffer(
         bisection_factor=bisection_factor,

--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -40,7 +40,7 @@ def _remove_passwords_in_dict(d: dict):
 @click.argument("table1", required=False)
 @click.argument("database2", required=False)
 @click.argument("table2", required=False)
-@click.option("-k", "--key-column", multiple=True, help="Names of primary key columns. Default='id'.")
+@click.option("-k", "--key-columns", multiple=True, help="Names of primary key columns. Default='id'.")
 @click.option("-t", "--update-column", default=None, help="Name of updated_at/last_updated column")
 @click.option("-c", "--columns", multiple=True, help="Names of extra columns to compare")
 @click.option("-l", "--limit", default=None, help="Maximum number of differences to find")
@@ -93,7 +93,7 @@ def _main(
     table1,
     database2,
     table2,
-    key_column,
+    key_columns,
     update_column,
     columns,
     limit,
@@ -130,7 +130,7 @@ def _main(
         logging.error("Cannot specify a limit when using the -s/--stats switch")
         return
 
-    key_columns = tuple(key_column) or ("id",)
+    key_columns = tuple(key_columns) or ("id",)
     if bisection_factor is None:
         bisection_factor = DEFAULT_BISECTION_FACTOR
     if bisection_threshold is None:

--- a/data_diff/databases/connect.py
+++ b/data_diff/databases/connect.py
@@ -80,7 +80,9 @@ MATCH_URI_PATH = {
     "presto": MatchUriPath(Presto, ["catalog", "schema"], help_str="presto://<user>@<host>/<catalog>/<schema>"),
     "bigquery": MatchUriPath(BigQuery, ["dataset"], help_str="bigquery://<project>/<dataset>"),
     "databricks": MatchUriPath(
-        Databricks, ["catalog", "schema"], help_str="databricks://:access_token@server_name/http_path",
+        Databricks,
+        ["catalog", "schema"],
+        help_str="databricks://:access_token@server_name/http_path",
     ),
     "trino": MatchUriPath(Trino, ["catalog", "schema"], help_str="trino://<user>@<host>/<catalog>/<schema>"),
 }
@@ -125,9 +127,9 @@ def connect_to_uri(db_uri: str, thread_count: Optional[int] = 1) -> Database:
     if scheme == "databricks":
         assert not dsn.user
         kw = {}
-        kw['access_token'] = dsn.password
-        kw['http_path'] = dsn.path
-        kw['server_hostname'] = dsn.host
+        kw["access_token"] = dsn.password
+        kw["http_path"] = dsn.path
+        kw["server_hostname"] = dsn.host
         kw.update(dsn.query)
     else:
         kw = matcher.match_path(dsn)

--- a/data_diff/databases/database_types.py
+++ b/data_diff/databases/database_types.py
@@ -1,6 +1,6 @@
 import decimal
 from abc import ABC, abstractmethod
-from typing import Sequence, Optional, Tuple, Union, Dict, Any
+from typing import Sequence, Optional, Tuple, Union, Dict, Any, List
 from datetime import datetime
 
 from runtype import dataclass
@@ -9,7 +9,7 @@ from data_diff.utils import ArithUUID
 
 
 DbPath = Tuple[str, ...]
-DbKey = Union[int, str, bytes, ArithUUID]
+DbKey = Tuple[Union[int, str, bytes, ArithUUID], ...]
 DbTime = datetime
 
 

--- a/data_diff/databases/oracle.py
+++ b/data_diff/databases/oracle.py
@@ -4,7 +4,8 @@ from .database_types import *
 from .base import ThreadedDatabase, import_helper, ConnectError, QueryError
 from .base import DEFAULT_DATETIME_PRECISION, DEFAULT_NUMERIC_PRECISION
 
-SESSION_TIME_ZONE = None    # Changed by the tests
+SESSION_TIME_ZONE = None  # Changed by the tests
+
 
 @import_helper("oracle")
 def import_oracle():

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -2,7 +2,8 @@ from .database_types import *
 from .base import ThreadedDatabase, import_helper, ConnectError
 from .base import MD5_HEXDIGITS, CHECKSUM_HEXDIGITS, _CHECKSUM_BITSIZE, TIMESTAMP_PRECISION_POS
 
-SESSION_TIME_ZONE = None    # Changed by the tests
+SESSION_TIME_ZONE = None  # Changed by the tests
+
 
 @import_helper("postgresql")
 def import_postgresql():
@@ -49,7 +50,7 @@ class PostgreSQL(ThreadedDatabase):
 
     def create_connection(self):
         if not self._args:
-            self._args['host'] = None   # psycopg2 requires 1+ arguments
+            self._args["host"] = None  # psycopg2 requires 1+ arguments
 
         pg = import_postgresql()
         try:

--- a/data_diff/databases/trino.py
+++ b/data_diff/databases/trino.py
@@ -66,7 +66,9 @@ class Trino(Database):
         else:
             s = f"date_format(cast({value} as timestamp(6)), '%Y-%m-%d %H:%i:%S.%f')"
 
-        return f"RPAD(RPAD({s}, {TIMESTAMP_PRECISION_POS + coltype.precision}, '.'), {TIMESTAMP_PRECISION_POS + 6}, '0')"
+        return (
+            f"RPAD(RPAD({s}, {TIMESTAMP_PRECISION_POS + coltype.precision}, '.'), {TIMESTAMP_PRECISION_POS + 6}, '0')"
+        )
 
     def normalize_number(self, value: str, coltype: FractionalType) -> str:
         return self.to_string(f"cast({value} as decimal(38,{coltype.precision}))")
@@ -96,9 +98,7 @@ class Trino(Database):
             if m:
                 datetime_precision = int(m.group(1))
                 return t_cls(
-                    precision=datetime_precision
-                    if datetime_precision is not None
-                    else DEFAULT_DATETIME_PRECISION,
+                    precision=datetime_precision if datetime_precision is not None else DEFAULT_DATETIME_PRECISION,
                     rounds=self.ROUNDS_ON_PREC_LOSS,
                 )
 
@@ -115,9 +115,7 @@ class Trino(Database):
             if m:
                 return n_cls()
 
-        return super()._parse_type(
-            table_path, col_name, type_repr, datetime_precision, numeric_precision
-        )
+        return super()._parse_type(table_path, col_name, type_repr, datetime_precision, numeric_precision)
 
     def normalize_uuid(self, value: str, coltype: ColType_UUID) -> str:
         return f"TRIM({value})"

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -248,12 +248,13 @@ class TableSegment:
         """Query database for minimum and maximum key. This is used for setting the initial bounds."""
         # Normalizes the result (needed for UUIDs) after the min/max computation
         select = self._make_select(
-            columns=[self._normalize_column(ki, f"{func}(%s)") for func in ("min", "max") for ki in self.key_columns]
+            columns=[self._normalize_column(ki, f"{func}(%s)") for ki in self.key_columns for func in ("min", "max")]
         )
         result = self.database.query(select, tuple)
         if any(i is None for i in result):
             raise ValueError("Table appears to be empty")
 
+        # Min/max keys are interleaved
         min_key, max_key = result[::2], result[1::2]
         assert len(min_key) == len(max_key)
 

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -60,8 +60,8 @@ class TableSegment:
         key_columns (List[str]): Name of the key column, which uniquely identifies each row (usually id)
         update_column (str, optional): Name of updated column, which signals that rows changed (usually updated_at or last_update)
         extra_columns (Tuple[str, ...], optional): Extra columns to compare
-        min_key (:data:`DbKey`, optional): Lowest key_column value, used to restrict the segment
-        max_key (:data:`DbKey`, optional): Highest key_column value, used to restrict the segment
+        min_key (:data:`DbKey`, optional): Lowest key value, used to restrict the segment
+        max_key (:data:`DbKey`, optional): Highest key value, used to restrict the segment
         min_update (:data:`DbTime`, optional): Lowest update_column value, used to restrict the segment
         max_update (:data:`DbTime`, optional): Highest update_column value, used to restrict the segment
 

--- a/data_diff/utils.py
+++ b/data_diff/utils.py
@@ -6,7 +6,8 @@ from uuid import UUID
 
 def safezip(*args):
     "zip but makes sure all sequences are the same length"
-    assert len(set(map(len, args))) == 1
+    if not len(set(map(len, args))) == 1:
+        raise ValueError(f"Uneven zip for {args}")
     return zip(*args)
 
 

--- a/tests/test_database_types.py
+++ b/tests/test_database_types.py
@@ -21,7 +21,7 @@ from .common import CONN_STRINGS, N_SAMPLES, N_THREADS, BENCHMARK, GIT_REVISION,
 CONNS = {k: db.connect_to_uri(v, N_THREADS) for k, v in CONN_STRINGS.items()}
 
 CONNS[db.MySQL].query("SET @@session.time_zone='+00:00'", None)
-oracle.SESSION_TIME_ZONE = postgresql.SESSION_TIME_ZONE = 'UTC'
+oracle.SESSION_TIME_ZONE = postgresql.SESSION_TIME_ZONE = "UTC"
 
 
 class PaginatedTable:
@@ -482,7 +482,7 @@ def _insert_to_table(conn, table, values, type):
             value = str(sample)
         elif isinstance(sample, datetime) and isinstance(conn, (db.Presto, db.Oracle, db.Trino)):
             value = f"timestamp '{sample}'"
-        elif isinstance(sample, datetime) and isinstance(conn, db.BigQuery) and type == 'datetime':
+        elif isinstance(sample, datetime) and isinstance(conn, db.BigQuery) and type == "datetime":
             value = f"cast(timestamp '{sample}' as datetime)"
         elif isinstance(sample, bytearray):
             value = f"'{sample.decode()}'"
@@ -617,11 +617,11 @@ class TestDiffCrossDatabaseTables(unittest.TestCase):
         insertion_target_duration = time.time() - start
 
         if type_category == "uuid":
-            self.table = TableSegment(self.src_conn, src_table_path, "col", None, ("id",), case_sensitive=False)
-            self.table2 = TableSegment(self.dst_conn, dst_table_path, "col", None, ("id",), case_sensitive=False)
+            self.table = TableSegment(self.src_conn, src_table_path, ("col",), None, ("id",), case_sensitive=False)
+            self.table2 = TableSegment(self.dst_conn, dst_table_path, ("col",), None, ("id",), case_sensitive=False)
         else:
-            self.table = TableSegment(self.src_conn, src_table_path, "id", None, ("col",), case_sensitive=False)
-            self.table2 = TableSegment(self.dst_conn, dst_table_path, "id", None, ("col",), case_sensitive=False)
+            self.table = TableSegment(self.src_conn, src_table_path, ("id",), None, ("col",), case_sensitive=False)
+            self.table2 = TableSegment(self.dst_conn, dst_table_path, ("id",), None, ("col",), case_sensitive=False)
 
         start = time.time()
         self.assertEqual(N_SAMPLES, self.table.count())

--- a/tests/test_database_types.py
+++ b/tests/test_database_types.py
@@ -357,12 +357,10 @@ DATABASE_TYPES = {
             "INT",
             "BIGINT",
         ],
-
         # https://docs.databricks.com/spark/latest/spark-sql/language-manual/data-types/timestamp-type.html
         "datetime": [
             "TIMESTAMP",
         ],
-
         # https://docs.databricks.com/spark/latest/spark-sql/language-manual/data-types/float-type.html
         # https://docs.databricks.com/spark/latest/spark-sql/language-manual/data-types/double-type.html
         # https://docs.databricks.com/spark/latest/spark-sql/language-manual/data-types/decimal-type.html
@@ -371,10 +369,9 @@ DATABASE_TYPES = {
             "DOUBLE",
             "DECIMAL(6, 2)",
         ],
-
         "uuid": [
             "STRING",
-        ]
+        ],
     },
     db.Trino: {
         "int": [
@@ -408,7 +405,7 @@ for source_db, source_type_categories in DATABASE_TYPES.items():
         ) in source_type_categories.items():  # int, datetime, ..
             for source_type in source_types:
                 for target_type in target_type_categories[type_category]:
-                    if (CONNS.get(source_db, False) and CONNS.get(target_db, False)):
+                    if CONNS.get(source_db, False) and CONNS.get(target_db, False):
                         type_pairs.append(
                             (
                                 source_db,

--- a/tests/test_diff_tables.py
+++ b/tests/test_diff_tables.py
@@ -89,15 +89,15 @@ class TestDates(TestWithConnection):
         self.preql.commit()
 
     def test_init(self):
-        a = TableSegment(self.connection, (self.table_src,), "id", "datetime", max_update=self.now.datetime)
+        a = TableSegment(self.connection, (self.table_src,), ("id",), "datetime", max_update=self.now.datetime)
         self.assertRaises(
-            ValueError, TableSegment, self.connection, (self.table_src,), "id", max_update=self.now.datetime
+            ValueError, TableSegment, self.connection, (self.table_src,), ("id",), max_update=self.now.datetime
         )
 
     def test_basic(self):
         differ = TableDiffer(10, 100)
-        a = TableSegment(self.connection, (self.table_src,), "id", "datetime")
-        b = TableSegment(self.connection, (self.table_dst,), "id", "datetime")
+        a = TableSegment(self.connection, (self.table_src,), ("id",), "datetime")
+        b = TableSegment(self.connection, (self.table_dst,), ("id",), "datetime")
         assert a.count() == 6
         assert b.count() == 5
 
@@ -107,24 +107,24 @@ class TestDates(TestWithConnection):
     def test_offset(self):
         differ = TableDiffer(2, 10)
         sec1 = self.now.shift(seconds=-1).datetime
-        a = TableSegment(self.connection, (self.table_src,), "id", "datetime", max_update=sec1)
-        b = TableSegment(self.connection, (self.table_dst,), "id", "datetime", max_update=sec1)
+        a = TableSegment(self.connection, (self.table_src,), ("id",), "datetime", max_update=sec1)
+        b = TableSegment(self.connection, (self.table_dst,), ("id",), "datetime", max_update=sec1)
         assert a.count() == 4
         assert b.count() == 3
 
         assert not list(differ.diff_tables(a, a))
         self.assertEqual(len(list(differ.diff_tables(a, b))), 1)
 
-        a = TableSegment(self.connection, (self.table_src,), "id", "datetime", min_update=sec1)
-        b = TableSegment(self.connection, (self.table_dst,), "id", "datetime", min_update=sec1)
+        a = TableSegment(self.connection, (self.table_src,), ("id",), "datetime", min_update=sec1)
+        b = TableSegment(self.connection, (self.table_dst,), ("id",), "datetime", min_update=sec1)
         assert a.count() == 2
         assert b.count() == 2
         assert not list(differ.diff_tables(a, b))
 
         day1 = self.now.shift(days=-1).datetime
 
-        a = TableSegment(self.connection, (self.table_src,), "id", "datetime", min_update=day1, max_update=sec1)
-        b = TableSegment(self.connection, (self.table_dst,), "id", "datetime", min_update=day1, max_update=sec1)
+        a = TableSegment(self.connection, (self.table_src,), ("id",), "datetime", min_update=day1, max_update=sec1)
+        b = TableSegment(self.connection, (self.table_dst,), ("id",), "datetime", min_update=day1, max_update=sec1)
         assert a.count() == 3
         assert b.count() == 2
         assert not list(differ.diff_tables(a, a))
@@ -160,8 +160,8 @@ class TestDiffTables(TestWithConnection):
         )
         self.preql.commit()
 
-        self.table = TableSegment(self.connection, (self.table_src,), "id", "timestamp")
-        self.table2 = TableSegment(self.connection, (self.table_dst,), "id", "timestamp")
+        self.table = TableSegment(self.connection, (self.table_src,), ("id",), "timestamp")
+        self.table2 = TableSegment(self.connection, (self.table_dst,), ("id",), "timestamp")
 
         self.differ = TableDiffer(3, 4)
 
@@ -294,8 +294,8 @@ class TestStringKeys(TestWithConnection):
         for query in queries:
             self.connection.query(query, None)
 
-        self.a = TableSegment(self.connection, (self.table_src,), "id", "comment")
-        self.b = TableSegment(self.connection, (self.table_dst,), "id", "comment")
+        self.a = TableSegment(self.connection, (self.table_src,), ("id",), "comment")
+        self.b = TableSegment(self.connection, (self.table_dst,), ("id",), "comment")
 
     def test_string_keys(self):
         differ = TableDiffer()
@@ -312,15 +312,15 @@ class TestStringKeys(TestWithConnection):
 class TestTableSegment(TestWithConnection):
     def setUp(self) -> None:
         super().setUp()
-        self.table = TableSegment(self.connection, (self.table_src,), "id", "timestamp")
-        self.table2 = TableSegment(self.connection, (self.table_dst,), "id", "timestamp")
+        self.table = TableSegment(self.connection, (self.table_src,), ("id",), "timestamp")
+        self.table2 = TableSegment(self.connection, (self.table_dst,), ("id",), "timestamp")
 
     def test_table_segment(self):
         early = datetime.datetime(2021, 1, 1, 0, 0)
         late = datetime.datetime(2022, 1, 1, 0, 0)
         self.assertRaises(ValueError, self.table.replace, min_update=late, max_update=early)
 
-        self.assertRaises(ValueError, self.table.replace, min_key=10, max_key=0)
+        self.assertRaises(ValueError, self.table.replace, min_key=(10,), max_key=(0,))
 
 
 class TestTableUUID(TestWithConnection):
@@ -346,8 +346,8 @@ class TestTableUUID(TestWithConnection):
         for query in queries:
             self.connection.query(query, None)
 
-        self.a = TableSegment(self.connection, (self.table_src,), "id", "comment")
-        self.b = TableSegment(self.connection, (self.table_dst,), "id", "comment")
+        self.a = TableSegment(self.connection, (self.table_src,), ("id",), "comment")
+        self.b = TableSegment(self.connection, (self.table_dst,), ("id",), "comment")
 
     def test_uuid_column_with_nulls(self):
         differ = TableDiffer()
@@ -374,8 +374,8 @@ class TestTableNullRowChecksum(TestWithConnection):
         for query in queries:
             self.connection.query(query, None)
 
-        self.a = TableSegment(self.connection, (self.table_src,), "id", "comment")
-        self.b = TableSegment(self.connection, (self.table_dst,), "id", "comment")
+        self.a = TableSegment(self.connection, (self.table_src,), ("id",), "comment")
+        self.b = TableSegment(self.connection, (self.table_dst,), ("id",), "comment")
 
     def test_uuid_columns_with_nulls(self):
         """
@@ -431,8 +431,8 @@ class TestConcatMultipleColumnWithNulls(TestWithConnection):
         for query in queries:
             self.connection.query(query, None)
 
-        self.a = TableSegment(self.connection, (self.table_src,), "id", extra_columns=("c1", "c2"))
-        self.b = TableSegment(self.connection, (self.table_dst,), "id", extra_columns=("c1", "c2"))
+        self.a = TableSegment(self.connection, (self.table_src,), ("id",), extra_columns=("c1", "c2"))
+        self.b = TableSegment(self.connection, (self.table_dst,), ("id",), extra_columns=("c1", "c2"))
 
     def test_tables_are_different(self):
         """
@@ -483,8 +483,8 @@ class TestTableTableEmpty(TestWithConnection):
         for query in queries:
             self.connection.query(query, None)
 
-        self.a = TableSegment(self.connection, (self.table_src,), "id", "comment")
-        self.b = TableSegment(self.connection, (self.table_dst,), "id", "comment")
+        self.a = TableSegment(self.connection, (self.table_src,), ("id",), "comment")
+        self.b = TableSegment(self.connection, (self.table_dst,), ("id",), "comment")
 
     def test_right_table_empty(self):
         differ = TableDiffer()

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -37,8 +37,8 @@ class TestWithConnection(unittest.TestCase):
         for query in queries:
             self.connection.query(query, None)
 
-        a = TableSegment(self.connection, (self.table_src,), "id", "comment")
-        b = TableSegment(self.connection, (self.table_dst,), "id", "comment")
+        a = TableSegment(self.connection, (self.table_src,), ("id",), "comment")
+        b = TableSegment(self.connection, (self.table_dst,), ("id",), "comment")
 
         differ = TableDiffer()
         diff = list(differ.diff_tables(a, b))


### PR DESCRIPTION
See: Issue #110

Changes `key_column: str` parameter to `key_columns: Tuple[str, ...]`, to allow diffing using multiple key columns.

Also changes the type of `min_key` and `max_key` similarly to a tuple.

This breaks backward compatibility for `TableSegment`, so I think we should bump the version to 0.3 