### PR TITLE
Added support for auto-detecting mutual columns, and using patterns in -c

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If a database is not on the list, we'd still love to support it. Open an issue
 to discuss it.
 
 Note: Because URLs allow many special characters, and may collide with the syntax of your command-line,
-it's recommended to surround them with quotes. Alternatively, you may provide them in a TOML file via the `--config` option. 
+it's recommended to surround them with quotes. Alternatively, you may provide them in a TOML file via the `--config` option.
 
 
 # How to install
@@ -195,7 +195,7 @@ Options:
   - `--help` - Show help message and exit.
   - `-k` or `--key-column` - Name of the primary key column
   - `-t` or `--update-column` - Name of updated_at/last_updated column
-  - `-c` or `--columns` - List of names of extra columns to compare
+  - `-c` or `--columns` - Name or pattern of extra columns to compare. Pattern syntax is like SQL, e.g. `%foob.r%`.
   - `-l` or `--limit` - Maximum number of differences to find (limits maximum bandwidth and runtime)
   - `-s` or `--stats` - Print stats instead of a detailed diff
   - `-d` or `--debug` - Print debug info

--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -180,7 +180,7 @@ class Database(AbstractDatabase):
             f"WHERE table_name = '{table}' AND table_schema = '{schema}'"
         )
 
-    def query_table_schema(self, path: DbPath) -> Dict[str, ColType]:
+    def query_table_schema(self, path: DbPath) -> Dict[str, tuple]:
         rows = self.query(self.select_table_schema(path), list)
         if not rows:
             raise RuntimeError(f"{self.name}: Table '{'.'.join(path)}' does not exist, or has no columns")
@@ -189,7 +189,7 @@ class Database(AbstractDatabase):
         assert len(d) == len(rows)
         return d
 
-    def _process_table_schema(self, path: DbPath, raw_schema: dict, filter_columns: Sequence[str]):
+    def _process_table_schema(self, path: DbPath, raw_schema: Dict[str, tuple], filter_columns: Sequence[str]):
         accept = {i.lower() for i in filter_columns}
 
         col_dict = {name: self._parse_type(path, *row) for name, row in raw_schema.items() if name.lower() in accept}

--- a/data_diff/databases/database_types.py
+++ b/data_diff/databases/database_types.py
@@ -1,6 +1,6 @@
 import decimal
 from abc import ABC, abstractmethod
-from typing import Mapping, Sequence, Optional, Tuple, Union, Dict, List
+from typing import Sequence, Optional, Tuple, Union, Dict, List
 from datetime import datetime
 
 from runtype import dataclass

--- a/data_diff/databases/database_types.py
+++ b/data_diff/databases/database_types.py
@@ -1,11 +1,11 @@
 import decimal
 from abc import ABC, abstractmethod
-from typing import Sequence, Optional, Tuple, Union, Dict, List
+from typing import Mapping, Sequence, Optional, Tuple, Union, Dict, List
 from datetime import datetime
 
 from runtype import dataclass
 
-from data_diff.utils import ArithAlphanumeric, ArithUUID, ArithString
+from data_diff.utils import ArithAlphanumeric, ArithUUID, CaseAwareMapping
 
 
 DbPath = Tuple[str, ...]
@@ -254,44 +254,4 @@ class AbstractDatabase(ABC):
         ...
 
 
-class Schema(ABC):
-    @abstractmethod
-    def get_key(self, key: str) -> str:
-        ...
-
-    @abstractmethod
-    def __getitem__(self, key: str) -> ColType:
-        ...
-
-    @abstractmethod
-    def __setitem__(self, key: str, value):
-        ...
-
-    @abstractmethod
-    def __contains__(self, key: str) -> bool:
-        ...
-
-
-class Schema_CaseSensitive(dict, Schema):
-    def get_key(self, key):
-        return key
-
-
-class Schema_CaseInsensitive(Schema):
-    def __init__(self, initial):
-        self._dict = {k.lower(): (k, v) for k, v in dict(initial).items()}
-
-    def get_key(self, key: str) -> str:
-        return self._dict[key.lower()][0]
-
-    def __getitem__(self, key: str) -> ColType:
-        return self._dict[key.lower()][1]
-
-    def __setitem__(self, key: str, value):
-        k = key.lower()
-        if k in self._dict:
-            key = self._dict[k][0]
-        self._dict[k] = key, value
-
-    def __contains__(self, key):
-        return key.lower() in self._dict
+Schema = CaseAwareMapping

--- a/data_diff/databases/database_types.py
+++ b/data_diff/databases/database_types.py
@@ -170,10 +170,24 @@ class AbstractDatabase(ABC):
         "Provide SQL for selecting the table schema as (name, type, date_prec, num_prec)"
         ...
 
+
     @abstractmethod
-    def query_table_schema(self, path: DbPath, filter_columns: Optional[Sequence[str]] = None) -> Dict[str, ColType]:
-        "Query the table for its schema for table in 'path', and return {column: type}"
+    def query_table_schema(self, path: DbPath) -> Dict[str, tuple]:
+        """Query the table for its schema for table in 'path', and return {column: tuple}
+          where the tuple is (table_name, col_name, type_repr, datetime_precision?, numeric_precision?, numeric_scale?)
+        """
         ...
+
+    @abstractmethod
+    def _process_table_schema(self, path: DbPath, raw_schema: Dict[str, tuple], filter_columns: Sequence[str]):
+        """Process the result of query_table_schema().
+
+        Done in a separate step, to minimize the amount of processed columns.
+        Needed because processing each column may:
+        * throw errors and warnings
+        * query the database to sample values
+
+        """
 
     @abstractmethod
     def parse_table_name(self, name: str) -> DbPath:

--- a/data_diff/databases/database_types.py
+++ b/data_diff/databases/database_types.py
@@ -170,11 +170,10 @@ class AbstractDatabase(ABC):
         "Provide SQL for selecting the table schema as (name, type, date_prec, num_prec)"
         ...
 
-
     @abstractmethod
     def query_table_schema(self, path: DbPath) -> Dict[str, tuple]:
         """Query the table for its schema for table in 'path', and return {column: tuple}
-          where the tuple is (table_name, col_name, type_repr, datetime_precision?, numeric_precision?, numeric_scale?)
+        where the tuple is (table_name, col_name, type_repr, datetime_precision?, numeric_precision?, numeric_scale?)
         """
         ...
 

--- a/data_diff/databases/databricks.py
+++ b/data_diff/databases/databricks.py
@@ -80,10 +80,9 @@ class Databricks(Database):
             if not rows:
                 raise RuntimeError(f"{self.name}: Table '{'.'.join(path)}' does not exist, or has no columns")
 
-            d = {r[0]: r for r in rows}
+            d = {r.COLUMN_NAME: r for r in rows}
             assert len(d) == len(rows)
             return d
-
 
     def _process_table_schema(self, path: DbPath, raw_schema: Dict[str, tuple], filter_columns: Sequence[str]):
         accept = {i.lower() for i in filter_columns}

--- a/data_diff/databases/mysql.py
+++ b/data_diff/databases/mysql.py
@@ -47,7 +47,7 @@ class MySQL(ThreadedDatabase):
             elif e.errno == mysql.errorcode.ER_BAD_DB_ERROR:
                 raise ConnectError("Database does not exist") from e
             else:
-                raise ConnectError(*e._args) from e
+                raise ConnectError(*e) from e
 
     def quote(self, s: str):
         return f"`{s}`"

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -13,10 +13,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from runtype import dataclass
 
 from .sql import Select, Checksum, Compare, DbPath, DbKey, DbTime, Count, TableName, Time, Value
-from .utils import CaseInsensitiveDict, safezip, split_space, CaseSensitiveDict
+from .utils import CaseAwareMapping, CaseInsensitiveDict, safezip, split_space, CaseSensitiveDict, ArithString
 from .databases.base import Database
 from .databases.database_types import (
-    ArithString,
     IKey,
     Native_UUID,
     NumericType,
@@ -33,7 +32,7 @@ DEFAULT_BISECTION_THRESHOLD = 1024 * 16
 DEFAULT_BISECTION_FACTOR = 32
 
 
-def create_schema(db: Database, table_path: DbPath, schema: dict, case_sensitive: bool) -> Schema:
+def create_schema(db: Database, table_path: DbPath, schema: dict, case_sensitive: bool) -> CaseAwareMapping:
     logger.debug(f"[{db.name}] Schema = {schema}")
 
     if case_sensitive:

--- a/data_diff/sql.py
+++ b/data_diff/sql.py
@@ -6,9 +6,9 @@ from datetime import datetime
 
 from runtype import dataclass
 
-from .utils import join_iter
+from .utils import join_iter, ArithString
 
-from .databases.database_types import AbstractDatabase, DbPath, DbKey, DbTime, ArithString
+from .databases.database_types import AbstractDatabase, DbPath, DbKey, DbTime
 
 
 class Sql:

--- a/data_diff/utils.py
+++ b/data_diff/utils.py
@@ -1,5 +1,6 @@
+import re
 import math
-from typing import Iterable, Tuple, Union, Any
+from typing import Iterable, Tuple, Union, Any, Sequence
 from typing import TypeVar, Generic
 from abc import ABC, abstractmethod
 from urllib.parse import urlparse
@@ -212,3 +213,10 @@ class CaseSensitiveDict(dict, CaseAwareMapping):
 
     def as_insensitive(self):
         return CaseInsensitiveDict(self)
+
+
+def match_like(pattern: str, strs: Sequence[str]) -> Iterable[str]:
+    reo = re.compile(pattern.replace("%", ".*").replace("?", ".") + "$")
+    for s in strs:
+        if reo.match(s):
+            yield s


### PR DESCRIPTION
Solves issue #83 .

@nolar This one didn't turn out as pretty as I'd like it to be.

Any suggestions? Or maybe it's the least of all evils?

**Explanation:**

We don't want to process column types that the user didn't request, because they might generate irrelevant warnings, or even errors for unsupported types. (and we also query the table for them, to figure out their 'refined' type)

But, we need the schema in order to choose the mutual columns.

And we need the mutual columns to choose which columns to process.

This is cyclical, so I break the cycle by working with "raw" schema until the mutual columns can be figured out.
