### PR TITLE
Fix so that `--min-age` and `--max-age` computed relative to database session time

### DIFF
--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -132,6 +132,9 @@ class BaseDialect(AbstractDialect, AbstractMixin_MD5, AbstractMixin_NormalizeVal
     def random(self) -> str:
         return "RANDOM()"
 
+    def current_timestamp(self) -> str:
+        return "SELECT CURRENT_TIMESTAMP()"
+
     def explain_as_text(self, query: str) -> str:
         return f"EXPLAIN {query}"
 
@@ -288,6 +291,10 @@ class Database(AbstractDatabase):
 
     def enable_interactive(self):
         self._interactive = True
+
+    def query_database_current_timestamp(self) -> datetime:
+        res = self._query(self.dialect.current_timestamp())
+        return _one(_one(res))
 
     def select_table_schema(self, path: DbPath) -> str:
         schema, table = self._normalize_table_path(path)

--- a/data_diff/databases/database_types.py
+++ b/data_diff/databases/database_types.py
@@ -184,6 +184,11 @@ class AbstractDialect(ABC):
         "Provide SQL for generating a random number betweein 0..1"
 
     @abstractmethod
+    def current_timestamp(self) -> str:
+        "Provide SQL for getting current time of database session"
+        ...
+
+    @abstractmethod
     def offset_limit(self, offset: Optional[int] = None, limit: Optional[int] = None):
         "Provide SQL fragment for limit and offset inside a select"
         ...
@@ -298,6 +303,11 @@ class AbstractDatabase:
     @abstractmethod
     def _query(self, sql_code: str) -> list:
         "Send query to database and return result"
+        ...
+
+    @abstractmethod
+    def query_database_current_timestamp(self) -> datetime:
+        "Query database for the current time"
         ...
 
     @abstractmethod

--- a/data_diff/parse_time.py
+++ b/data_diff/parse_time.py
@@ -7,6 +7,10 @@ class ParseError(ValueError):
     pass
 
 
+class TimeZoneError(ValueError):
+    pass
+
+
 TIME_UNITS = dict(
     seconds="seconds",
     minutes="minutes",
@@ -72,3 +76,7 @@ def parse_time_delta(t: str):
 
 def parse_time_before_now(t: str):
     return datetime.now() - parse_time_delta(t)
+
+
+def parse_database_time_before_now(t: str, db_dt: datetime):
+    return db_dt - parse_time_delta(t)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -32,6 +32,9 @@ class MockDialect(AbstractDialect):
     def random(self) -> str:
         return "random()"
 
+    def current_timestamp(self) -> str:
+        return "select current_timestamp()"
+
     def offset_limit(self, offset: Optional[int] = None, limit: Optional[int] = None):
         x = offset and f"offset {offset}", limit and f"limit {limit}"
         return " ".join(filter(None, x))


### PR DESCRIPTION
This PR is related to a recently opened Issue (#284 ). The PR is currently in draft format, awaiting further discussion on the Issue tracker.

The PR currently attempts to minimally extend some of the original data structures to retrieve a timestamp for a database session. It also re-orders the the sequence of logic slightly in `__main__.py` so that `--min-age` and `--max-age` can be computed relative to the database session timestamps.

It's not clear to me how to handle the case where both databases have different timezones, or whether this is really worth considering. At the moment, I just log and return.