### PR TITLE
Update typing of TableSegment().count()

### DIFF
--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -154,7 +154,7 @@ class TableSegment:
     def _relevant_columns_repr(self) -> List[Expr]:
         return [NormalizeAsString(this[c]) for c in self.relevant_columns]
 
-    def count(self) -> Tuple[int, int]:
+    def count(self) -> int:
         """Count how many rows are in the segment, in one pass."""
         return self.database.query(self.make_select().select(Count()), int)
 


### PR DESCRIPTION
On my side when dst is a TableSegment object, dst.count() returns an int. Using `data-diff==0.2.8`