### PR TITLE
Add redshift external tables

### DIFF
--- a/data_diff/sqeleton/databases/base.py
+++ b/data_diff/sqeleton/databases/base.py
@@ -339,8 +339,6 @@ class Database(AbstractDatabase):
 
     def query_table_schema(self, path: DbPath) -> Dict[str, tuple]:
         rows = self.query(self.select_table_schema(path), list)
-        if not rows and self.name == 'Redshift':
-            rows = self.query(self.select_external_table_schema(path), list)
         if not rows:
             raise RuntimeError(f"{self.name}: Table '{'.'.join(path)}' does not exist, or has no columns")
 

--- a/data_diff/sqeleton/databases/base.py
+++ b/data_diff/sqeleton/databases/base.py
@@ -339,6 +339,8 @@ class Database(AbstractDatabase):
 
     def query_table_schema(self, path: DbPath) -> Dict[str, tuple]:
         rows = self.query(self.select_table_schema(path), list)
+        if not rows and self.name == 'Redshift':
+            rows = self.query(self.select_external_table_schema(path), list)
         if not rows:
             raise RuntimeError(f"{self.name}: Table '{'.'.join(path)}' does not exist, or has no columns")
 

--- a/data_diff/sqeleton/databases/redshift.py
+++ b/data_diff/sqeleton/databases/redshift.py
@@ -70,3 +70,18 @@ class Redshift(PostgreSQL):
             "SELECT column_name, data_type, datetime_precision, numeric_precision, numeric_scale FROM information_schema.columns "
             f"WHERE table_name = '{table.lower()}' AND table_schema = '{schema.lower()}'"
         )
+
+    def select_external_table_schema(self, path: DbPath) -> str:
+        schema, table = self._normalize_table_path(path)
+
+        return (
+            f"""SELECT
+                columnname AS column_name
+                , CASE WHEN external_type = 'string' THEN 'varchar' ELSE external_type END AS data_type
+                , NULL AS datetime_precision
+                , NULL AS numeric_precision
+                , NULL AS numeric_scale
+            FROM svv_external_columns
+                WHERE tablename = '{table.lower()}' AND schemaname = '{schema.lower()}'
+            """
+        )


### PR DESCRIPTION
## Description

Existing `data-diff` redshift capabilities are unable to read external tables. These are found in the `svv_external_columns` table. 

Original thought was to add a database flag `-e --external-table` but I don't believe flags can be specific to one database connection and not the other. A simpler approach is to simply query the external tables in redshift if none was found in the redshift one.

* Adding `select_external_table_schema` in redshift sqeleton
* Add condition to query redshift external tables if no results were found in the redshift database.