### PR TITLE
add usage type tracking

### DIFF
--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -20,7 +20,7 @@ from .sqeleton.queries.api import current_timestamp
 from .databases import connect
 from .parse_time import parse_time_before, UNITS_STR, ParseError
 from .config import apply_config_from_file
-from .tracking import disable_tracking
+from .tracking import disable_tracking, set_entrypoint_name
 from .version import __version__
 
 
@@ -32,6 +32,7 @@ COLOR_SCHEME = {
     "-": "red",
 }
 
+set_entrypoint_name("CLI")
 
 def _remove_passwords_in_dict(d: dict):
     for k, v in d.items():

--- a/data_diff/tracking.py
+++ b/data_diff/tracking.py
@@ -40,6 +40,8 @@ def _load_profile():
 g_tracking_enabled = True
 g_anonymous_id = None
 
+entrypoint_name = "Python API"
+
 
 def disable_tracking():
     global g_tracking_enabled
@@ -48,6 +50,11 @@ def disable_tracking():
 
 def is_tracking_enabled():
     return g_tracking_enabled
+
+
+def set_entrypoint_name(s):
+    global entrypoint_name
+    entrypoint_name = s
 
 
 def get_anonymous_id():
@@ -70,6 +77,7 @@ def create_start_event_json(diff_options: Dict[str, Any]):
             "python_version": f"{platform.python_version()}/{platform.python_implementation()}",
             "diff_options": diff_options,
             "data_diff_version:": __version__,
+            "entrypoint_name": entrypoint_name,
         },
     }
 
@@ -99,6 +107,7 @@ def create_end_event_json(
             "diff_rows_cnt": diff_count,
             "error_message": error,
             "data_diff_version:": __version__,
+            "entrypoint_name": entrypoint_name,
         },
     }
 


### PR DESCRIPTION
**Summary**
This PR adds tracking to differentiate diffs triggered by CLI vs Python API

**Detail**
* adds `set_usage_mode(str)` to `tracking.py`
* sets usage mode to "CLI" and "Python API" in `__main__` and `__init__` respectively
* passes `usage mode` as event properties

I called it "usage mode", but am very very open to alternative naming conventions if something better communicates this property.

**Testing**
Example Python API diff:
<img width="877" alt="Screen Shot 2022-12-12 at 9 03 50 AM" src="https://user-images.githubusercontent.com/40182913/207110847-84481270-1c9b-4800-8f14-11a082fd5dd7.png">

Example CLI diff
<img width="964" alt="Screen Shot 2022-12-12 at 9 25 44 AM" src="https://user-images.githubusercontent.com/40182913/207112497-6a2658a6-f713-48cc-88ac-4899db309e16.png">


**Formatting**
```
data-diff [track_cli_vs_python●] black data_diff/tracking.py                                            
All done! ✨ 🍰 ✨
1 file left unchanged.
```