### PR TITLE
Fix typos

### DIFF
--- a/data_diff/config.py
+++ b/data_diff/config.py
@@ -29,7 +29,7 @@ def _apply_config(config: Dict[str, Any], run_name: str, kw: Dict[str, Any]):
     if kw.get("database1") is not None:
         for attr in ("table1", "database2", "table2"):
             if kw[attr] is None:
-                raise ValueError(f"Specified database1 but not {attr}. Must specify all 4 arguments, or niether.")
+                raise ValueError(f"Specified database1 but not {attr}. Must specify all 4 arguments, or neither.")
 
         for index in "12":
             run_args[index] = {attr: kw.pop(f"{attr}{index}") for attr in ("database", "table")}

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -49,7 +49,7 @@ class HashDiffer(TableDiffer):
     The algorithm uses hashing to quickly check if the tables are different, and then applies a
     bisection search recursively to find the differences efficiently.
 
-    Works best for comparing tables that are mostly the same, with minor discrepencies.
+    Works best for comparing tables that are mostly the same, with minor discrepancies.
 
     Parameters:
         bisection_factor (int): Into how many segments to bisect per iteration.

--- a/dev/prepare_db.pql
+++ b/dev/prepare_db.pql
@@ -1,4 +1,4 @@
-// This is a Preql file, used for setting up a database for developement and testing
+// This is a Preql file, used for setting up a database for development and testing
 //
 // In loads a "rating" dataset and generates a set of tables from it, with various modifications.
 

--- a/dev/prepare_db_gaps.pql
+++ b/dev/prepare_db_gaps.pql
@@ -1,4 +1,4 @@
-// This is a Preql file, used for setting up a database for developement and testing
+// This is a Preql file, used for setting up a database for development and testing
 //
 // It generates tables with various gaps in them, based on the "rating" dataset.
 // Assumes prepare_db.pql has already been run.

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -14,7 +14,7 @@ Run the following command:
 
 Where DB is either a database URL that's compatible with SQLAlchemy, or the name of a database specified in a configuration file.
 
-We recommend using a configuration file, with the ``--conf`` switch, to keep the command simple and managable.
+We recommend using a configuration file, with the ``--conf`` switch, to keep the command simple and manageable.
 
 For a list of example URLs, see [list of supported databases](supported-databases.md).
 
@@ -150,7 +150,7 @@ We capture two events: one when the data-diff run starts, and one when it is fin
 - Types of databases used (postgresql, mysql, etc.)
 - Sizes of tables diffed, run time, and diff row count (numbers only)
 - Error message, if any, truncated to the first 20 characters.
-- A persistent UUID to indentify the session, stored in `~/.datadiff.toml`
+- A persistent UUID to identify the session, stored in `~/.datadiff.toml`
 
 If you do not wish to participate, the tracking can be easily disabled with one of the following methods:
 


### PR DESCRIPTION
Found via `codespell -S .mypy_cache -L ro`