### PR TITLE
spruce up CLI output in dbt context

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -151,7 +151,7 @@ def _local_diff(diff_vars: DiffVars) -> None:
             + prod_qualified_string
             + "[/] \n"
             + column_diffs_str
-            + diff.get_stats_string()
+            + diff.get_stats_string_dbt()
             + "\n"
         )
     else:

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -151,7 +151,7 @@ def _local_diff(diff_vars: DiffVars) -> None:
             + prod_qualified_string
             + "[/] \n"
             + column_diffs_str
-            + diff.get_stats_string_dbt()
+            + diff.get_stats_string(is_dbt=True)
             + "\n"
         )
     else:

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -104,10 +104,9 @@ class DiffResultWrapper:
     def _get_stats(self, is_dbt:bool = False) -> DiffStats:
         list(self)  # Consume the iterator into result_list, if we haven't already
 
-        
         key_columns = self.info_tree.info.tables[0].key_columns
         diff_by_key = {}
-
+        extra_column_diffs = None
         if is_dbt:
             extra_column_values_store = {}
             extra_columns = self.info_tree.info.tables[0].extra_columns
@@ -137,16 +136,13 @@ class DiffResultWrapper:
         table2_count = self.info_tree.info.rowcounts[2]
         unchanged = table1_count - diff_by_sign["-"] - diff_by_sign["!"]
         diff_percent = 1 - unchanged / max(table1_count, table2_count)
-        if is_dbt:
-            return DiffStats(diff_by_sign, table1_count, table2_count, unchanged, diff_percent, extra_column_diffs)
-        else:
-            return DiffStats(diff_by_sign, table1_count, table2_count, unchanged, diff_percent, None)
+
+        return DiffStats(diff_by_sign, table1_count, table2_count, unchanged, diff_percent, extra_column_diffs)
 
     def get_stats_string(self, is_dbt:bool = False):
 
-        diff_stats = self._get_stats()
+        diff_stats = self._get_stats(is_dbt)
         if is_dbt:
-            diff_stats = self._get_stats(is_dbt=True)
             
             string_output = "\n| Rows Added\t| Rows Removed\n"
             string_output += "------------------------------------------------------------\n"

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -166,15 +166,7 @@ class DiffResultWrapper:
     def get_stats_string_dbt(self):
 
         diff_stats = self._get_stats_dbt()
-        string_output = ""
-        string_output += f"{diff_stats.table1_count} rows in table A\n"
-        string_output += f"{diff_stats.table2_count} rows in table B\n"
-        string_output += f"{diff_stats.diff_by_sign['-']} rows exclusive to table A (not present in B)\n"
-        string_output += f"{diff_stats.diff_by_sign['+']} rows exclusive to table B (not present in A)\n"
-        string_output += f"{diff_stats.diff_by_sign['!']} rows updated\n"
-        string_output += f"{diff_stats.unchanged} rows unchanged\n"
-        string_output += f"{100*diff_stats.diff_percent:.2f}% difference score\n"
-
+        
         string_output = "\n| Rows Added\t| Rows Removed\n"
         string_output += "------------------------------------------------------------\n"
 

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -101,7 +101,7 @@ class DiffResultWrapper:
             self.result_list.append(i)
             yield i
 
-    def _get_stats(self) -> DiffStats:
+    def _get_stats(self, is_dbt:bool = False) -> DiffStats:
         list(self)  # Consume the iterator into result_list, if we haven't already
 
         

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -101,7 +101,7 @@ class DiffResultWrapper:
             self.result_list.append(i)
             yield i
 
-    def _get_stats(self, is_dbt:bool = False) -> DiffStats:
+    def _get_stats(self, is_dbt: bool = False) -> DiffStats:
         list(self)  # Consume the iterator into result_list, if we haven't already
 
         key_columns = self.info_tree.info.tables[0].key_columns
@@ -111,18 +111,17 @@ class DiffResultWrapper:
         if is_dbt:
             extra_column_values_store = {}
             extra_columns = self.info_tree.info.tables[0].extra_columns
-            extra_column_diffs = {k:0 for k in extra_columns}
+            extra_column_diffs = {k: 0 for k in extra_columns}
 
         for sign, values in self.result_list:
-            len_key_columns = 
-            k = values[: len_key_columns]
+            k = values[:len_key_columns]
             if is_dbt:
-                extra_column_values = values[len_key_columns :]
+                extra_column_values = values[len_key_columns:]
             if k in diff_by_key:
                 assert sign != diff_by_key[k]
                 diff_by_key[k] = "!"
                 if is_dbt:
-                    for i in range(0,len(extra_columns)):
+                    for i in range(0, len(extra_columns)):
                         if extra_column_values[i] != extra_column_values_store[k][i]:
                             extra_column_diffs[extra_columns[i]] += 1
             else:
@@ -141,11 +140,11 @@ class DiffResultWrapper:
 
         return DiffStats(diff_by_sign, table1_count, table2_count, unchanged, diff_percent, extra_column_diffs)
 
-    def get_stats_string(self, is_dbt:bool = False):
+    def get_stats_string(self, is_dbt: bool = False):
 
         diff_stats = self._get_stats(is_dbt)
         if is_dbt:
-            
+
             string_output = "\n| Rows Added\t| Rows Removed\n"
             string_output += "------------------------------------------------------------\n"
 
@@ -173,7 +172,7 @@ class DiffResultWrapper:
             if self.stats:
                 string_output += "\nExtra-Info:\n"
                 for k, v in sorted(self.stats.items()):
-                    string_output += f"  {k} = {v}\n"         
+                    string_output += f"  {k} = {v}\n"
 
         return string_output
 

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -146,7 +146,7 @@ class DiffResultWrapper:
 
         diff_stats = self._get_stats()
         if is_dbt:
-            diff_stats = self._get_stats_dbt()
+            diff_stats = self._get_stats(is_dbt=True)
             
             string_output = "\n| Rows Added\t| Rows Removed\n"
             string_output += "------------------------------------------------------------\n"

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -104,49 +104,30 @@ class DiffResultWrapper:
     def _get_stats(self) -> DiffStats:
         list(self)  # Consume the iterator into result_list, if we haven't already
 
-        diff_by_key = {}
-        for sign, values in self.result_list:
-            k = values[: len(self.info_tree.info.tables[0].key_columns)]
-            if k in diff_by_key:
-                assert sign != diff_by_key[k]
-                diff_by_key[k] = "!"
-            else:
-                diff_by_key[k] = sign
-
-        diff_by_sign = {k: 0 for k in "+-!"}
-        for sign in diff_by_key.values():
-            diff_by_sign[sign] += 1
-
-        table1_count = self.info_tree.info.rowcounts[1]
-        table2_count = self.info_tree.info.rowcounts[2]
-        unchanged = table1_count - diff_by_sign["-"] - diff_by_sign["!"]
-        diff_percent = 1 - unchanged / max(table1_count, table2_count)
-
-        return DiffStats(diff_by_sign, table1_count, table2_count, unchanged, diff_percent, None)
-
-    def _get_stats_dbt(self) -> DiffStats:
-        list(self)  # Consume the iterator into result_list, if we haven't already
-
+        
         key_columns = self.info_tree.info.tables[0].key_columns
         diff_by_key = {}
-        extra_column_values_store = {}
 
-        extra_columns = self.info_tree.info.tables[0].extra_columns
-        extra_column_diffs = {k:0 for k in extra_columns}
+        if is_dbt:
+            extra_column_values_store = {}
+            extra_columns = self.info_tree.info.tables[0].extra_columns
+            extra_column_diffs = {k:0 for k in extra_columns}
 
         for sign, values in self.result_list:
-            k = values[: len(self.info_tree.info.tables[0].key_columns)]
-            extra_column_values = values[len(self.info_tree.info.tables[0].key_columns) :]
+            k = values[: len(key_columns)]
+            if is_dbt:
+                extra_column_values = values[len(self.info_tree.info.tables[0].key_columns) :]
             if k in diff_by_key:
                 assert sign != diff_by_key[k]
                 diff_by_key[k] = "!"
-                for i in range(0,len(extra_columns)):
-
-                    if extra_column_values[i] != extra_column_values_store[k][i]:
-                        extra_column_diffs[extra_columns[i]] += 1
+                if is_dbt:
+                    for i in range(0,len(extra_columns)):
+                        if extra_column_values[i] != extra_column_values_store[k][i]:
+                            extra_column_diffs[extra_columns[i]] += 1
             else:
                 diff_by_key[k] = sign
-                extra_column_values_store[k] = extra_column_values
+                if is_dbt:
+                    extra_column_values_store[k] = extra_column_values
 
         diff_by_sign = {k: 0 for k in "+-!"}
         for sign in diff_by_key.values():
@@ -156,10 +137,14 @@ class DiffResultWrapper:
         table2_count = self.info_tree.info.rowcounts[2]
         unchanged = table1_count - diff_by_sign["-"] - diff_by_sign["!"]
         diff_percent = 1 - unchanged / max(table1_count, table2_count)
+        if is_dbt:
+            return DiffStats(diff_by_sign, table1_count, table2_count, unchanged, diff_percent, extra_column_diffs)
+        else:
+            return DiffStats(diff_by_sign, table1_count, table2_count, unchanged, diff_percent, None)
 
-        return DiffStats(diff_by_sign, table1_count, table2_count, unchanged, diff_percent, extra_column_diffs)
+    def get_stats_string(self, is_dbt:bool = False):
 
-    def get_stats_string(self):
+
 
         diff_stats = self._get_stats()
         string_output = ""
@@ -204,7 +189,7 @@ class DiffResultWrapper:
             string_output += f"\n{k}: {v}"
 
         return string_output
-        
+
     def get_stats_dict(self):
 
         diff_stats = self._get_stats()

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -105,6 +105,7 @@ class DiffResultWrapper:
         list(self)  # Consume the iterator into result_list, if we haven't already
 
         key_columns = self.info_tree.info.tables[0].key_columns
+        len_key_columns = len(key_columns)
         diff_by_key = {}
         extra_column_diffs = None
         if is_dbt:
@@ -113,9 +114,10 @@ class DiffResultWrapper:
             extra_column_diffs = {k:0 for k in extra_columns}
 
         for sign, values in self.result_list:
-            k = values[: len(key_columns)]
+            len_key_columns = 
+            k = values[: len_key_columns]
             if is_dbt:
-                extra_column_values = values[len(self.info_tree.info.tables[0].key_columns) :]
+                extra_column_values = values[len_key_columns :]
             if k in diff_by_key:
                 assert sign != diff_by_key[k]
                 diff_by_key[k] = "!"

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -85,7 +85,7 @@ class DiffStats:
     table2_count: int
     unchanged: int
     diff_percent: float
-    extra_column_diffs: Dict[str, int]
+    extra_column_diffs: Optional[Dict[str, int]]
 
 
 @dataclass

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -144,41 +144,38 @@ class DiffResultWrapper:
 
     def get_stats_string(self, is_dbt:bool = False):
 
-
-
         diff_stats = self._get_stats()
-        string_output = ""
-        string_output += f"{diff_stats.table1_count} rows in table A\n"
-        string_output += f"{diff_stats.table2_count} rows in table B\n"
-        string_output += f"{diff_stats.diff_by_sign['-']} rows exclusive to table A (not present in B)\n"
-        string_output += f"{diff_stats.diff_by_sign['+']} rows exclusive to table B (not present in A)\n"
-        string_output += f"{diff_stats.diff_by_sign['!']} rows updated\n"
-        string_output += f"{diff_stats.unchanged} rows unchanged\n"
-        string_output += f"{100*diff_stats.diff_percent:.2f}% difference score\n"
+        if is_dbt:
+            diff_stats = self._get_stats_dbt()
+            
+            string_output = "\n| Rows Added\t| Rows Removed\n"
+            string_output += "------------------------------------------------------------\n"
 
-        if self.stats:
-            string_output += "\nExtra-Info:\n"
-            for k, v in sorted(self.stats.items()):
-                string_output += f"  {k} = {v}\n"
+            string_output += f"| {diff_stats.diff_by_sign['-']}\t\t| {diff_stats.diff_by_sign['+']}\n"
+            string_output += "------------------------------------------------------------\n\n"
+            string_output += f"Updated Rows: {diff_stats.diff_by_sign['!']}\n"
+            string_output += f"Identical Rows: {diff_stats.unchanged}\n\n"
 
-        return string_output
+            string_output += f"Values Updated:"
 
-    def get_stats_string_dbt(self):
+            for k, v in diff_stats.extra_column_diffs.items():
+                string_output += f"\n{k}: {v}"
 
-        diff_stats = self._get_stats_dbt()
-        
-        string_output = "\n| Rows Added\t| Rows Removed\n"
-        string_output += "------------------------------------------------------------\n"
+        else:
 
-        string_output += f"| {diff_stats.diff_by_sign['-']}\t\t| {diff_stats.diff_by_sign['+']}\n"
-        string_output += "------------------------------------------------------------\n\n"
-        string_output += f"Updated Rows: {diff_stats.diff_by_sign['!']}\n"
-        string_output += f"Identical Rows: {diff_stats.unchanged}\n\n"
+            string_output = ""
+            string_output += f"{diff_stats.table1_count} rows in table A\n"
+            string_output += f"{diff_stats.table2_count} rows in table B\n"
+            string_output += f"{diff_stats.diff_by_sign['-']} rows exclusive to table A (not present in B)\n"
+            string_output += f"{diff_stats.diff_by_sign['+']} rows exclusive to table B (not present in A)\n"
+            string_output += f"{diff_stats.diff_by_sign['!']} rows updated\n"
+            string_output += f"{diff_stats.unchanged} rows unchanged\n"
+            string_output += f"{100*diff_stats.diff_percent:.2f}% difference score\n"
 
-        string_output += f"Values Updated:"
-
-        for k, v in diff_stats.extra_column_diffs.items():
-            string_output += f"\n{k}: {v}"
+            if self.stats:
+                string_output += "\nExtra-Info:\n"
+                for k, v in sorted(self.stats.items()):
+                    string_output += f"  {k} = {v}\n"         
 
         return string_output
 

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -150,7 +150,7 @@ class DiffResultWrapper:
             string_output += f"| {diff_stats.diff_by_sign['-']}\t\t| {diff_stats.diff_by_sign['+']}\n"
             string_output += "------------------------------------------------------------\n\n"
             string_output += f"Updated Rows: {diff_stats.diff_by_sign['!']}\n"
-            string_output += f"Identical Rows: {diff_stats.unchanged}\n\n"
+            string_output += f"Unchanged Rows: {diff_stats.unchanged}\n\n"
 
             string_output += f"Values Updated:"
 


### PR DESCRIPTION
My attempt at improving the CLI printout without using any additional python packages.

BEFORE:
<img width="1158" alt="Screenshot 2023-02-01 at 23 54 09" src="https://user-images.githubusercontent.com/1799931/216264362-5b0edebf-f4b5-40fd-87c7-0023b364b6af.png">


AFTER:
<img width="618" alt="Screenshot 2023-02-01 at 23 52 48" src="https://user-images.githubusercontent.com/1799931/216264345-b07569f4-7e1f-4d99-974f-4352c0495cd4.png">

TODO based on comments in https://github.com/dlawin/data-diff/pull/3:

- [x] @erezsh: Looks like _get_stats_dbt() should instead just be a flag to _get_stats() https://github.com/dlawin/data-diff/pull/3#issuecomment-1413855643
- [ ] @erezsh: Better to implement this using zip() / safezip() https://github.com/dlawin/data-diff/pull/3#discussion_r1094628001
- [x] @dlawin: Since we're adding a parameter here, we'll need to account for it in the other DiffStats() in this file https://github.com/dlawin/data-diff/pull/3#discussion_r1095035933
- [x] @dlawin : update `get_stats_string(self, is_dbt:bool = False):` ... add the additional functionality there and just wrap it in an `if is_dbt:` https://github.com/dlawin/data-diff/pull/3#issuecomment-1414321053
- [x] @dlawin : line length