### PR TITLE
fix issue 391 incorrect raise, add tests

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -54,8 +54,8 @@ def dbt_diff(
     if not is_cloud:
         dbt_parser.set_connection()
 
-    if config_prod_database is None or config_prod_schema is None:
-        raise ValueError("Expected a value for prod_database: or prod_schema: under \nvars:\n  data_diff: ")
+    if config_prod_database is None or (config_prod_database is None and config_prod_schema is None):
+        raise ValueError("Expected a value for prod_database: OR prod_database: AND prod_schema: under \nvars:\n  data_diff: ")
 
     for model in models:
         diff_vars = _get_diff_vars(dbt_parser, config_prod_database, config_prod_schema, model, datasource_id)

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -54,7 +54,7 @@ def dbt_diff(
     if not is_cloud:
         dbt_parser.set_connection()
 
-    if config_prod_database is None or (config_prod_database is None and config_prod_schema is None):
+    if config_prod_database is None:
         raise ValueError(
             "Expected a value for prod_database: OR prod_database: AND prod_schema: under \nvars:\n  data_diff: "
         )

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -55,7 +55,9 @@ def dbt_diff(
         dbt_parser.set_connection()
 
     if config_prod_database is None or (config_prod_database is None and config_prod_schema is None):
-        raise ValueError("Expected a value for prod_database: OR prod_database: AND prod_schema: under \nvars:\n  data_diff: ")
+        raise ValueError(
+            "Expected a value for prod_database: OR prod_database: AND prod_schema: under \nvars:\n  data_diff: "
+        )
 
     for model in models:
         diff_vars = _get_diff_vars(dbt_parser, config_prod_database, config_prod_schema, model, datasource_id)


### PR DESCRIPTION
Closes #391 

We are inadvertently raising an exception when specifying only `prod_database:`

Added tests to cover the possible scenarios

Expected (no exception):
```
dbt_vars_dict = {
            "prod_database": "prod_db",
            "prod_schema": "prod_schema",
            "datasource_id": 1,
        }
```
```
dbt_vars_dict = {
            "prod_database": "prod_db",
            "datasource_id": 1,
        }
```

Exception
```
dbt_vars_dict = {
            "datasource_id": 1,
        }
```
```
dbt_vars_dict = {
            "datasource_id": 1,
            "prod_schema": "prod_schema",
        }
```
