### PR TITLE
Key Range Query adjustments

### DIFF
--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -1,5 +1,5 @@
 import time
-from typing import List, Tuple, Literal
+from typing import List, Tuple
 import logging
 
 from runtype import dataclass
@@ -202,22 +202,6 @@ class TableSegment:
             raise ValueError("Table appears to be empty")
 
         return min_key, max_key
-
-    def query_key_bound(self, bound: Literal['min', 'max']) -> int:
-        """Query database for min OR max of key. This is used for setting the initial bounds."""
-        # Normalizes the result (needed for UUIDs) after the min computation
-
-        bound_expr = min_ if bound == 'min' else max_
-        (k,) = self.key_columns
-        select = self.make_select(include_key_range=False).select(
-            ApplyFuncAndNormalizeAsString(this[k], bound_expr)
-        )
-        min_or_max_key = self.database.query(select, str)
-
-        if min_or_max_key is None:
-            raise ValueError("Table appears to be empty")
-
-        return min_or_max_key[0][0]
 
     @property
     def is_bounded(self):

--- a/tests/test_diff_tables.py
+++ b/tests/test_diff_tables.py
@@ -301,48 +301,32 @@ class TestDiffTables(DiffTestCase):
         self.assertEqual(expected, diff)
 
     @patch.object(TableSegment, 'query_key_range')
-    @patch.object(TableSegment, 'query_key_bound')
-    def test_key_bounds(self, mock_query_key_bound, mock_query_key_range):
+    def test_key_bounds(self, mock_query_key_range):
         # test range query when no min/max provided
         mock_query_key_range.return_value = (0, 10)
         _ = list(self.differ.diff_tables(self.table, self.table2))
         mock_query_key_range.assert_called()
-        mock_query_key_bound.assert_not_called()
 
-        # test no range or bounds query
+        # test no range query
         mock_query_key_range.reset_mock()
-        mock_query_key_bound.reset_mock()
-
         tbl1 = self.table.replace(min_key=1, max_key=100)
         tbl2 = self.table2.replace(min_key=1, max_key=100)
-
         _ = list(self.differ.diff_tables(tbl1, tbl2))
         mock_query_key_range.assert_not_called()
-        mock_query_key_bound.assert_not_called()
 
         # test query min only
         mock_query_key_range.reset_mock()
-        mock_query_key_bound.reset_mock()
-
         tbl1 = self.table.replace(max_key=100)
         tbl2 = self.table2.replace(max_key=100)
-
         _ = list(self.differ.diff_tables(tbl1, tbl2))
-        mock_query_key_range.assert_not_called()
-        mock_query_key_bound.assert_called_with(bound='min')
+        mock_query_key_range.assert_called()
 
-        # test query max only
+        # test query min only
         mock_query_key_range.reset_mock()
-        mock_query_key_bound.reset_mock()
-        mock_query_key_bound.return_value = 1000
-
-        tbl1 = self.table.replace(max_key=None, min_key=100)
-        tbl2 = self.table2.replace(max_key=None, min_key=100)
-
+        tbl1 = self.table.replace(min_key=0)
+        tbl2 = self.table2.replace(min_key=0)
         _ = list(self.differ.diff_tables(tbl1, tbl2))
-        mock_query_key_range.assert_not_called()
-        mock_query_key_bound.assert_called_with(bound='max')
-
+        mock_query_key_range.assert_called()
 
 
 @test_each_database


### PR DESCRIPTION
**Changes**
- If `min_key` + `max_key` are both passed in as parameters, the `query_key_range` query is bypassed
- If only one of `min_key` or `max_key` are passed in, `query_key_range` is called but the min or max is overridden with the user-provided value.

fixes [#401](https://github.com/datafold/data-diff/issues/401)