### PR TITLE
revise columns added-removed output

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -145,10 +145,10 @@ def _local_diff(diff_vars: DiffVars) -> None:
     table2_set_diff = list(set(table2_columns) - set(table1_columns))
 
     if table1_set_diff:
-        column_diffs_str += "Columns exclusive to table A: " + str(table1_set_diff) + "\n"
+        column_diffs_str += "Column(s) added: " + str(table1_set_diff) + "\n"
 
     if table2_set_diff:
-        column_diffs_str += "Columns exclusive to table B: " + str(table2_set_diff) + "\n"
+        column_diffs_str += "Column(s) removed: " + str(table2_set_diff) + "\n"
 
     mutual_set.discard(primary_key)
     extra_columns = tuple(mutual_set)


### PR DESCRIPTION
Resolves #420 

"Columns exclusive to table A/B" is very literal, and does not immediately convey changes. This PR changes the output to more user friendly  "Columns added/removed" language.

Example change, removing a column and adding a column
<img width="1264" alt="Screen Shot 2023-02-27 at 1 48 17 PM" src="https://user-images.githubusercontent.com/40182913/221694087-7991ea9c-1ed5-47a7-8e65-834d78c27dbf.png">

Revised output with "Columns added/removed" rather than "exclusive to table A/B"
<img width="534" alt="Screen Shot 2023-02-27 at 1 48 47 PM" src="https://user-images.githubusercontent.com/40182913/221694466-2c844b18-ea15-4a57-8c30-8ee7ff7fa0e2.png">
