### PR TITLE
support custom schemas

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -60,7 +60,7 @@ def dbt_diff(
     config_prod_database = datadiff_variables.get("prod_database")
     config_prod_schema = datadiff_variables.get("prod_schema")
     datasource_id = datadiff_variables.get("datasource_id")
-    custom_schema = datadiff_variables.get("custom_schema")
+    disable_custom_schemas = datadiff_variables.get("disable_custom_schemas")
 
     if not is_cloud:
         dbt_parser.set_connection()
@@ -72,7 +72,7 @@ def dbt_diff(
 
     for model in models:
         diff_vars = _get_diff_vars(
-            dbt_parser, config_prod_database, config_prod_schema, model, datasource_id, custom_schema
+            dbt_parser, config_prod_database, config_prod_schema, model, datasource_id, disable_custom_schemas
         )
 
         if is_cloud and len(diff_vars.primary_keys) > 0:
@@ -98,7 +98,7 @@ def _get_diff_vars(
     config_prod_schema: Optional[str],
     model,
     datasource_id: int,
-    custom_schema: Optional[bool],
+    disable_custom_schemas: Optional[bool],
 ) -> DiffVars:
     dev_database = model.database
     dev_schema = model.schema_
@@ -107,10 +107,10 @@ def _get_diff_vars(
     prod_database = config_prod_database if config_prod_database else dev_database
     prod_schema = config_prod_schema if config_prod_schema else dev_schema
 
-    # if project has custom_schemas: True
+    # if project has not disabled custom schemas
     # need to construct the prod schema as <prod_target_schema>_<custom_schema>
     # https://docs.getdbt.com/docs/build/custom-schemas
-    if custom_schema and model.config.schema_:
+    if not disable_custom_schemas and model.config.schema_:
         prod_schema = prod_schema + "_" + model.config.schema_
 
     if dbt_parser.requires_upper:

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -60,7 +60,9 @@ def dbt_diff(
     config_prod_database = datadiff_variables.get("prod_database")
     config_prod_schema = datadiff_variables.get("prod_schema")
     datasource_id = datadiff_variables.get("datasource_id")
-    disable_custom_schemas = datadiff_variables.get("disable_custom_schemas")
+    custom_schemas = datadiff_variables.get("custom_schemas")
+    # custom schemas is default dbt behavior, so default to True if the var doesn't exist
+    custom_schemas = True if custom_schemas is None else custom_schemas
 
     if not is_cloud:
         dbt_parser.set_connection()
@@ -72,7 +74,7 @@ def dbt_diff(
 
     for model in models:
         diff_vars = _get_diff_vars(
-            dbt_parser, config_prod_database, config_prod_schema, model, datasource_id, disable_custom_schemas
+            dbt_parser, config_prod_database, config_prod_schema, model, datasource_id, custom_schemas
         )
 
         if is_cloud and len(diff_vars.primary_keys) > 0:
@@ -98,7 +100,7 @@ def _get_diff_vars(
     config_prod_schema: Optional[str],
     model,
     datasource_id: int,
-    disable_custom_schemas: Optional[bool],
+    custom_schemas: bool,
 ) -> DiffVars:
     dev_database = model.database
     dev_schema = model.schema_
@@ -107,10 +109,10 @@ def _get_diff_vars(
     prod_database = config_prod_database if config_prod_database else dev_database
     prod_schema = config_prod_schema if config_prod_schema else dev_schema
 
-    # if project has not disabled custom schemas
+    # if project has custom schemas (default)
     # need to construct the prod schema as <prod_target_schema>_<custom_schema>
     # https://docs.getdbt.com/docs/build/custom-schemas
-    if not disable_custom_schemas and model.config.schema_:
+    if custom_schemas and model.config.schema_:
         prod_schema = prod_schema + "_" + model.config.schema_
 
     if dbt_parser.requires_upper:

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -60,6 +60,7 @@ def dbt_diff(
     config_prod_database = datadiff_variables.get("prod_database")
     config_prod_schema = datadiff_variables.get("prod_schema")
     datasource_id = datadiff_variables.get("datasource_id")
+    custom_schema = datadiff_variables.get("custom_schema")
 
     if not is_cloud:
         dbt_parser.set_connection()
@@ -70,7 +71,9 @@ def dbt_diff(
         )
 
     for model in models:
-        diff_vars = _get_diff_vars(dbt_parser, config_prod_database, config_prod_schema, model, datasource_id)
+        diff_vars = _get_diff_vars(
+            dbt_parser, config_prod_database, config_prod_schema, model, datasource_id, custom_schema
+        )
 
         if is_cloud and len(diff_vars.primary_keys) > 0:
             _cloud_diff(diff_vars)
@@ -95,6 +98,7 @@ def _get_diff_vars(
     config_prod_schema: Optional[str],
     model,
     datasource_id: int,
+    custom_schema: Optional[bool],
 ) -> DiffVars:
     dev_database = model.database
     dev_schema = model.schema_
@@ -102,6 +106,12 @@ def _get_diff_vars(
 
     prod_database = config_prod_database if config_prod_database else dev_database
     prod_schema = config_prod_schema if config_prod_schema else dev_schema
+
+    # if project has custom_schemas: True
+    # need to construct the prod schema as <prod_target_schema>_<custom_schema>
+    # https://docs.getdbt.com/docs/build/custom-schemas
+    if custom_schema and model.config.schema_:
+        prod_schema = prod_schema + "_" + model.config.schema_
 
     if dbt_parser.requires_upper:
         dev_qualified_list = [x.upper() for x in [dev_database, dev_schema, model.alias]]
@@ -111,7 +121,9 @@ def _get_diff_vars(
         dev_qualified_list = [dev_database, dev_schema, model.alias]
         prod_qualified_list = [prod_database, prod_schema, model.alias]
 
-    return DiffVars(dev_qualified_list, prod_qualified_list, primary_keys, datasource_id, dbt_parser.connection, dbt_parser.threads)
+    return DiffVars(
+        dev_qualified_list, prod_qualified_list, primary_keys, datasource_id, dbt_parser.connection, dbt_parser.threads
+    )
 
 
 def _local_diff(diff_vars: DiffVars) -> None:
@@ -119,8 +131,12 @@ def _local_diff(diff_vars: DiffVars) -> None:
     dev_qualified_string = ".".join(diff_vars.dev_path)
     prod_qualified_string = ".".join(diff_vars.prod_path)
 
-    table1 = connect_to_table(diff_vars.connection, dev_qualified_string, tuple(diff_vars.primary_keys), diff_vars.threads)
-    table2 = connect_to_table(diff_vars.connection, prod_qualified_string, tuple(diff_vars.primary_keys), diff_vars.threads)
+    table1 = connect_to_table(
+        diff_vars.connection, dev_qualified_string, tuple(diff_vars.primary_keys), diff_vars.threads
+    )
+    table2 = connect_to_table(
+        diff_vars.connection, prod_qualified_string, tuple(diff_vars.primary_keys), diff_vars.threads
+    )
 
     table1_columns = list(table1.get_schema())
     try:


### PR DESCRIPTION
Resolves #404 

Adds support for custom schemas, with a new data_diff var
Example (custom schema environments):
```
vars:
  data_diff:
    prod_schema: BEERS
    prod_database: INTEGRATION
```
No need to do anything here, custom_schemas is assumed to be True
prod path = `<prod_database>.<prod_schema>_<custom_schema>.<model>` if the model _has_ a custom schema.
else:
prod path = `<prod_database>.<prod_schema>.<model>`



Setting `custom_schemas: False` would cause the prod comparison path to be `<prod_database>.<prod_schema>.<model>` or `<prod_database>.<same_schema_as_dev_model>.<model>` based on the existence of the `prod_schema` variable (existing behavior).


Example (schema environments):
```
    prod_schema: BEERS
    prod_database: INTEGRATION
    custom_schemas: False
```
prod path = `<prod_database>.<prod_schema>.<model>`

Example (database environments):
```
    prod_database: INTEGRATION
    custom_schemas: False
```
prod path = `<prod_database>.<same_schema_as_dev_model>.<model>`