### PR TITLE
Add support for empty database variable in Databricks

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -101,9 +101,9 @@ def dbt_diff(
         else:
             rich.print(
                 "[red]"
-                + ".".join(diff_vars.prod_path)
+                + ".".join(filter(None, diff_vars.prod_path))
                 + " <> "
-                + ".".join(diff_vars.dev_path)
+                + ".".join(filter(None, diff_vars.dev_path))
                 + "[/] \n"
                 + "Skipped due to missing primary-key tag(s).\n"
             )
@@ -147,8 +147,8 @@ def _get_diff_vars(
 
 def _local_diff(diff_vars: DiffVars) -> None:
     column_diffs_str = ""
-    dev_qualified_string = ".".join(diff_vars.dev_path)
-    prod_qualified_string = ".".join(diff_vars.prod_path)
+    dev_qualified_string = ".".join(filter(None, diff_vars.dev_path))
+    prod_qualified_string = ".".join(filter(None, diff_vars.prod_path))
 
     table1 = connect_to_table(
         diff_vars.connection, dev_qualified_string, tuple(diff_vars.primary_keys), diff_vars.threads
@@ -252,9 +252,9 @@ def _cloud_diff(diff_vars: DiffVars) -> None:
         diff_url = f"https://app.datafold.com/datadiffs/{diff_id}/overview"
         rich.print(
             "[red]"
-            + ".".join(diff_vars.prod_path)
+            + ".".join(filter(None, diff_vars.prod_path))
             + " <> "
-            + ".".join(diff_vars.dev_path)
+            + ".".join(filter(None, diff_vars.dev_path))
             + "[/] \n    Diff in progress: \n    "
             + diff_url
             + "\n"


### PR DESCRIPTION
The database is not a required variable in Databricks when the user doesn't use Unity Catalogue so can often be empty. This change filters out any `None` from the dev_path/prod_path list before joining to prevent an error:

```
DiffVars(dev_path=[None, 'dev_schema', 'model_a'], prod_path=[None, 'prod_schema', 'model_a'], primary_keys=[], datasource_id=None, connection={'driver': 'databricks', 'catalog': None, 'server_hostname': 'host.cloud.databricks.com', 'http_path': '/sql/1.0/endpoints/abcdef', 'schema': 'schema', 'access_token': 'xxx'}, threads=20)
```

To do this I have used these variables in the project.yml - could expand on this and just make them optional altogether for Databricks which might be cleaner. 
```
  data_diff:
    prod_database: ''
    prod_schema: 'prod_schema'
```

Before:
```
(repo) ➜  repo git:(test-branch) ✗ pipenv run dbt run --select model_test --project-dir project_dir && pipenv run data-diff --dbt --dbt-project-dir project_dir -d
Loading .env environment variables...
08:24:55  Running with dbt=1.4.1
08:25:13  Found 1 models, 2 tests, 0 snapshots, 0 analyses, 0 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
08:25:13  
08:25:15  
08:25:15  
08:25:15  Concurrency: 20 threads (target='dev')
08:25:15  
08:25:15  1 of 1 START sql view model dev_schema.model_test ...... [RUN]
08:25:16  1 of 1 OK created sql view model dev_schema.model_test . [OK in 0.85s]
08:25:16  
08:25:16  
08:25:17  
08:25:17  Finished running 1 view model in 0 hours 0 minutes and 3.33 seconds (3.33s).
08:25:17  
08:25:17  Completed successfully
08:25:17  
08:25:17  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
Loading .env environment variables...
Found 1 successful model runs from the last dbt command.
[09:25:22] ERROR - sequence item 0: expected str instance, NoneType found
Traceback (most recent call last):
  File "/repo-path/bin/data-diff", line 8, in <module>
    sys.exit(main())
  File "/repo-path/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/repo-path/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/repo-path/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/repo-path/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/repo-path/lib/python3.10/site-packages/data_diff/__main__.py", line 263, in main
    dbt_diff(
  File "/repo-path/lib/python3.10/site-packages/data_diff/dbt.py", line 100, in dbt_diff
    _local_diff(diff_vars)
  File "/repo-path/lib/python3.10/site-packages/data_diff/dbt.py", line 150, in _local_diff
    dev_qualified_string = ".".join(diff_vars.dev_path)
TypeError: sequence item 0: expected str instance, NoneType found
```

After:
```
(repo) ➜  repo git:(test-branch) ✗ pipenv run dbt run --select model_test --project-dir project_dir && pipenv run data-diff --dbt --dbt-project-dir project_dir -d
Loading .env environment variables...
08:19:57  Running with dbt=1.4.1
08:20:15  Found 1 models, 2 tests, 0 snapshots, 0 analyses, 0 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
08:20:15  
08:20:17  
08:20:17  
08:20:17  Concurrency: 20 threads (target='dev')
08:20:17  
08:20:17  1 of 1 START sql view model dev_schema.model_test ...... [RUN]
08:20:18  1 of 1 OK created sql view model dev_schema.model_test . [OK in 0.87s]
08:20:18  
08:20:18  
08:20:18  
08:20:18  Finished running 1 view model in 0 hours 0 minutes and 2.85 seconds (2.85s).
08:20:18  
08:20:18  Completed successfully
08:20:18  
08:20:18  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
Loading .env environment variables...
Found 1 successful model runs from the last dbt command.
[09:20:23] INFO - [Databricks] Starting a threadpool, size=20.
[09:20:23] DEBUG - Running SQL (Databricks): SET TIME ZONE 'UTC'
[09:20:25] DEBUG - [Databricks] Schema = {'col_a': Integer(precision=0, python_type=<class 'int'>)}
[09:20:25] DEBUG - [Databricks] Schema = {'col_a': Integer(precision=0, python_type=<class 'int'>)}
[09:20:25] DEBUG - Testing for duplicate keys
[09:20:25] INFO - Validating that the are no duplicate keys in columns: ['col_a']
[09:20:25] DEBUG - Running SQL (Databricks): SELECT count(*) AS `total`, count(distinct coalesce(cast(`col_a` as string), '<null>')) AS `total_distinct` FROM `dev_schema`.`model_test`
[09:20:25] DEBUG - Running SQL (Databricks): SELECT cast(min(`col_a`) as string), cast(max(`col_a`) as string) FROM `dev_schema`.`model_test`
[09:20:26] DEBUG - Running SQL (Databricks): SELECT cast(min(`col_a`) as string), cast(max(`col_a`) as string) FROM `prod_schema`.`model_test`
[09:20:26] INFO - Diffing segments at key-range: (1)..(3). size: table1 <= 2, table2 <= 2
[09:20:26] INFO - . Diffing segment 1/2, key-range: (1)..(2), size <= None
[09:20:26] DEBUG - Collecting stats for table #1
[09:20:26] DEBUG - Running SQL (Databricks): SELECT count(*) AS `count` FROM `dev_schema`.`model_test` WHERE (`col_a` >= 1) AND (`col_a` < 2)
[09:20:26] DEBUG - Querying for different rows
[09:20:26] DEBUG - Running SQL (Databricks): SELECT * FROM (SELECT (`tmp2`.`col_a` IS NULL) AS `is_exclusive_a`, (`tmp1`.`col_a` IS NULL) AS `is_exclusive_b`, CASE WHEN `tmp1`.`col_a` is distinct from `tmp2`.`col_a` THEN 1 ELSE 0 END AS `is_diff_col_a`, cast(`tmp1`.`col_a` as string) AS `col_a_a`, cast(`tmp2`.`col_a` as string) AS `col_a_b` FROM (SELECT * FROM `dev_schema`.`model_test` WHERE (`col_a` >= 1) AND (`col_a` < 2)) `tmp1` FULL OUTER JOIN (SELECT * FROM `prod_schema`.`model_test` WHERE (`col_a` >= 1) AND (`col_a` < 2)) `tmp2` ON (`tmp1`.`col_a` = `tmp2`.`col_a`)) tmp3 WHERE (`is_diff_col_a` = 1)
[09:20:26] INFO - Validating that the are no duplicate keys in columns: ['col_a']
[09:20:26] DEBUG - Running SQL (Databricks): SELECT count(*) AS `total`, count(distinct coalesce(cast(`col_a` as string), '<null>')) AS `total_distinct` FROM `prod_schema`.`model_test`
[09:20:26] DEBUG - Done collecting stats for table #1
[09:20:26] DEBUG - Collecting stats for table #2
[09:20:26] DEBUG - Running SQL (Databricks): SELECT count(*) AS `count` FROM `prod_schema`.`model_test` WHERE (`col_a` >= 1) AND (`col_a` < 2)
[09:20:27] DEBUG - Done collecting stats for table #2
[09:20:27] DEBUG - Testing for null keys
[09:20:27] DEBUG - Running SQL (Databricks): SELECT `col_a` FROM `dev_schema`.`model_test` WHERE (`col_a` >= 1) AND (`col_a` < 2) AND (`col_a` IS NULL)
[09:20:27] DEBUG - Running SQL (Databricks): SELECT `col_a` FROM `prod_schema`.`model_test` WHERE (`col_a` >= 1) AND (`col_a` < 2) AND (`col_a` IS NULL)
[09:20:27] DEBUG - Counting exclusive rows
[09:20:27] DEBUG - Running SQL (Databricks): SELECT count(*) FROM (SELECT * FROM (SELECT (`tmp2`.`col_a` IS NULL) AS `is_exclusive_a`, (`tmp1`.`col_a` IS NULL) AS `is_exclusive_b`, CASE WHEN `tmp1`.`col_a` is distinct from `tmp2`.`col_a` THEN 1 ELSE 0 END AS `is_diff_col_a`, cast(`tmp1`.`col_a` as string) AS `col_a_a`, cast(`tmp2`.`col_a` as string) AS `col_a_b` FROM (SELECT * FROM `dev_schema`.`model_test` WHERE (`col_a` >= 1) AND (`col_a` < 2)) `tmp1` FULL OUTER JOIN (SELECT * FROM `prod_schema`.`model_test` WHERE (`col_a` >= 1) AND (`col_a` < 2)) `tmp2` ON (`tmp1`.`col_a` = `tmp2`.`col_a`)) tmp3 WHERE (`is_diff_col_a` = 1) AND (`is_exclusive_a` OR `is_exclusive_b`)) tmp4
[09:20:27] DEBUG - Counting differences per column
[09:20:27] DEBUG - Running SQL (Databricks): SELECT sum(`is_diff_col_a`) FROM (SELECT (`tmp2`.`col_a` IS NULL) AS `is_exclusive_a`, (`tmp1`.`col_a` IS NULL) AS `is_exclusive_b`, CASE WHEN `tmp1`.`col_a` is distinct from `tmp2`.`col_a` THEN 1 ELSE 0 END AS `is_diff_col_a`, cast(`tmp1`.`col_a` as string) AS `col_a_a`, cast(`tmp2`.`col_a` as string) AS `col_a_b` FROM (SELECT * FROM `dev_schema`.`model_test` WHERE (`col_a` >= 1) AND (`col_a` < 2)) `tmp1` FULL OUTER JOIN (SELECT * FROM `prod_schema`.`model_test` WHERE (`col_a` >= 1) AND (`col_a` < 2)) `tmp2` ON (`tmp1`.`col_a` = `tmp2`.`col_a`)) tmp3 WHERE (`is_diff_col_a` = 1)
[09:20:28] INFO - . Diffing segment 2/2, key-range: (2)..(3), size <= None
[09:20:28] DEBUG - Collecting stats for table #1
[09:20:28] DEBUG - Running SQL (Databricks): SELECT count(*) AS `count` FROM `dev_schema`.`model_test` WHERE (`col_a` >= 2) AND (`col_a` < 3)
[09:20:28] DEBUG - Querying for different rows
[09:20:28] DEBUG - Running SQL (Databricks): SELECT * FROM (SELECT (`tmp2`.`col_a` IS NULL) AS `is_exclusive_a`, (`tmp1`.`col_a` IS NULL) AS `is_exclusive_b`, CASE WHEN `tmp1`.`col_a` is distinct from `tmp2`.`col_a` THEN 1 ELSE 0 END AS `is_diff_col_a`, cast(`tmp1`.`col_a` as string) AS `col_a_a`, cast(`tmp2`.`col_a` as string) AS `col_a_b` FROM (SELECT * FROM `dev_schema`.`model_test` WHERE (`col_a` >= 2) AND (`col_a` < 3)) `tmp1` FULL OUTER JOIN (SELECT * FROM `prod_schema`.`model_test` WHERE (`col_a` >= 2) AND (`col_a` < 3)) `tmp2` ON (`tmp1`.`col_a` = `tmp2`.`col_a`)) tmp3 WHERE (`is_diff_col_a` = 1)
[09:20:28] DEBUG - Done collecting stats for table #1
[09:20:28] DEBUG - Collecting stats for table #2
[09:20:28] DEBUG - Running SQL (Databricks): SELECT count(*) AS `count` FROM `prod_schema`.`model_test` WHERE (`col_a` >= 2) AND (`col_a` < 3)
[09:20:28] DEBUG - Done collecting stats for table #2
[09:20:28] DEBUG - Testing for null keys
[09:20:28] DEBUG - Running SQL (Databricks): SELECT `col_a` FROM `dev_schema`.`model_test` WHERE (`col_a` >= 2) AND (`col_a` < 3) AND (`col_a` IS NULL)
[09:20:28] DEBUG - Running SQL (Databricks): SELECT `col_a` FROM `prod_schema`.`model_test` WHERE (`col_a` >= 2) AND (`col_a` < 3) AND (`col_a` IS NULL)
[09:20:29] DEBUG - Counting exclusive rows
[09:20:29] DEBUG - Running SQL (Databricks): SELECT count(*) FROM (SELECT * FROM (SELECT (`tmp2`.`col_a` IS NULL) AS `is_exclusive_a`, (`tmp1`.`col_a` IS NULL) AS `is_exclusive_b`, CASE WHEN `tmp1`.`col_a` is distinct from `tmp2`.`col_a` THEN 1 ELSE 0 END AS `is_diff_col_a`, cast(`tmp1`.`col_a` as string) AS `col_a_a`, cast(`tmp2`.`col_a` as string) AS `col_a_b` FROM (SELECT * FROM `dev_schema`.`model_test` WHERE (`col_a` >= 2) AND (`col_a` < 3)) `tmp1` FULL OUTER JOIN (SELECT * FROM `prod_schema`.`model_test` WHERE (`col_a` >= 2) AND (`col_a` < 3)) `tmp2` ON (`tmp1`.`col_a` = `tmp2`.`col_a`)) tmp3 WHERE (`is_diff_col_a` = 1) AND (`is_exclusive_a` OR `is_exclusive_b`)) tmp4
[09:20:29] DEBUG - Counting differences per column
[09:20:29] DEBUG - Running SQL (Databricks): SELECT sum(`is_diff_col_a`) FROM (SELECT (`tmp2`.`col_a` IS NULL) AS `is_exclusive_a`, (`tmp1`.`col_a` IS NULL) AS `is_exclusive_b`, CASE WHEN `tmp1`.`col_a` is distinct from `tmp2`.`col_a` THEN 1 ELSE 0 END AS `is_diff_col_a`, cast(`tmp1`.`col_a` as string) AS `col_a_a`, cast(`tmp2`.`col_a` as string) AS `col_a_b` FROM (SELECT * FROM `dev_schema`.`model_test` WHERE (`col_a` >= 2) AND (`col_a` < 3)) `tmp1` FULL OUTER JOIN (SELECT * FROM `prod_schema`.`model_test` WHERE (`col_a` >= 2) AND (`col_a` < 3)) `tmp2` ON (`tmp1`.`col_a` = `tmp2`.`col_a`)) tmp3 WHERE (`is_diff_col_a` = 1)
[09:20:30] INFO - Diffing complete
prod_schema.model_test <> dev_schema.model_test 

| Rows Added    | Rows Removed
------------------------------------------------------------
| 1             | 0
------------------------------------------------------------

Updated Rows: 0
Unchanged Rows: 1

Values Updated:

Diffs Complete!
```

 