### PR TITLE
Allow for Snowflake key-pair authentication with `--dbt`

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -374,9 +374,6 @@ class DbtParser:
     @staticmethod
     def _get_snowflake_private_key(credentials):
         """Get Snowflake private key by path, from a Base64 encoded DER bytestring or None."""
-        if credentials.get("private_key") and credentials.get("private_key_path"):
-            raise Exception("Cannot specify both `private_key`  and `private_key_path`")
-
         if credentials.get("private_key_passphrase"):
             encoded_passphrase = credentials.get("private_key_passphrase").encode()
         else:
@@ -417,9 +414,14 @@ class DbtParser:
                 "role": credentials.get("role"),
                 "schema": credentials.get("schema"),
             }
+
             if credentials.get("password") is not None:
+                if credentials.get("private_key") is not None or credentials.get("private_key_path") is not None:
+                    raise Exception("Cannot use password and key at the same time")
                 conn_info["password"] = credentials.get("password")
             else:
+                if credentials.get("private_key") is not None and credentials.get("private_key_path") is not None:
+                    raise Exception("Cannot specify both `private_key` and `private_key_path`")
                 conn_info["private_key"] = self._get_snowflake_private_key(credentials)
             self.threads = credentials.get("threads")
             self.requires_upper = True

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -144,7 +144,7 @@ class TestDbtParser(unittest.TestCase):
         self.assertEqual(mock_self.project_dict, expected_dict)
         mock_open.assert_called_once_with(Path(PROJECT_FILE))
 
-    def test_set_connection_snowflake_success(self):
+    def test_set_connection_snowflake_password_success(self):
         expected_driver = "snowflake"
         expected_credentials = {"user": "user", "password": "password"}
         mock_self = Mock()
@@ -158,7 +158,52 @@ class TestDbtParser(unittest.TestCase):
         self.assertEqual(mock_self.connection.get("password"), expected_credentials["password"])
         self.assertEqual(mock_self.requires_upper, True)
 
-    def test_set_connection_snowflake_no_password(self):
+    def test_set_connection_snowflake_private_key_success(self):
+        expected_driver = "snowflake"
+        expected_credentials = {"user": "user", "private_key": "password", "private_key_passphrase": "pass"}
+        expected_connection = {"user": "user", "private_key": "password"}
+        mock_self = Mock()
+        mock_self._get_connection_creds.return_value = (expected_credentials, expected_driver)
+        mock_self._get_snowflake_private_key.return_value = expected_connection["private_key"]
+
+        DbtParser.set_connection(mock_self)
+
+        self.assertIsInstance(mock_self.connection, dict)
+        self.assertEqual(mock_self.connection.get("driver"), expected_driver)
+        self.assertEqual(mock_self.connection.get("user"), expected_connection["user"])
+        self.assertEqual(mock_self.connection.get("private_key"), expected_connection["private_key"])
+        self.assertEqual(mock_self.connection.get("private_key_passphrase"), None)
+        self.assertEqual(mock_self.requires_upper, True)
+
+    def test_set_connection_snowflake_private_key_path_success(self):
+        expected_driver = "snowflake"
+        expected_credentials = {"user": "user", "private_key_path": "password", "private_key_passphrase": "pass"}
+        expected_connection = {"user": "user", "private_key": "password"}
+        mock_self = Mock()
+        mock_self._get_connection_creds.return_value = (expected_credentials, expected_driver)
+        mock_self._get_snowflake_private_key.return_value = expected_connection["private_key"]
+
+        DbtParser.set_connection(mock_self)
+
+        self.assertIsInstance(mock_self.connection, dict)
+        self.assertEqual(mock_self.connection.get("driver"), expected_driver)
+        self.assertEqual(mock_self.connection.get("user"), expected_connection["user"])
+        self.assertEqual(mock_self.connection.get("private_key"), expected_connection["private_key"])
+        self.assertEqual(mock_self.connection.get("private_key_passphrase"), None)
+        self.assertEqual(mock_self.requires_upper, True)
+
+    def test_set_connection_snowflake_multiple_authentication(self):
+        expected_driver = "snowflake"
+        expected_credentials = {"user": "user", "password": "password", "private_key": "password"}
+        mock_self = Mock()
+        mock_self._get_connection_creds.return_value = (expected_credentials, expected_driver)
+
+        with self.assertRaises(Exception):
+            DbtParser.set_connection(mock_self)
+
+        self.assertNotIsInstance(mock_self.connection, dict)
+
+    def test_set_connection_snowflake_no_authentication(self):
         expected_driver = "snowflake"
         expected_credentials = {"user": "user"}
         mock_self = Mock()


### PR DESCRIPTION
Adds support for key-pair authentication with Snowflake with dbt; namely supports dbt profile options:
```yml
...
private_key_passphrase: <...>
private_key_path: <...>
# or
private_key: <...>
```

Running locally with the correct key-pair provides message (indicating a successful authentication):
```bash
❯ poetry run python3 -m data_diff --dbt
Found 1 successful model runs from the last dbt command.
[15:07:12] ERROR - 002003 (02000): SQL compilation error:
Database 'XXX' does not exist or not authorized.
```

And with incorrect key-pair:
```bash
❯ poetry run python3 -m data_diff --dbt
Found 1 successful model runs from the last dbt command.
[15:49:02] ERROR - Bad decrypt. Incorrect password?
```

While this works, this code does not handle situations where a user incorrectly provides both a password and a key/key path; if both are provided, the password is preferred. 
The code, prior to this contribution, does not appear to take a stance on error handling with respect to different types of authentication; I am hoping a maintainer can provide an opinion on this. I am happy to add unit tests and modify the existing code after the route forward has been decided