### PR TITLE
Adding user id to tracking

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -29,6 +29,7 @@ def import_dbt():
 
 from .tracking import (
     set_entrypoint_name,
+    set_dbt_user_id,
     create_end_event_json,
     create_start_event_json,
     send_event_json,
@@ -84,6 +85,7 @@ def dbt_diff(
     custom_schemas = datadiff_variables.get("custom_schemas")
     # custom schemas is default dbt behavior, so default to True if the var doesn't exist
     custom_schemas = True if custom_schemas is None else custom_schemas
+    set_dbt_user_id(dbt_parser.dbt_user_id)
 
     if not is_cloud:
         dbt_parser.set_connection()
@@ -299,6 +301,7 @@ class DbtParser:
         self.connection = None
         self.project_dict = self.get_project_dict()
         self.manifest_obj = self.get_manifest_obj()
+        self.dbt_user_id = self.manifest_obj.metadata.user_id
         self.requires_upper = False
         self.threads = None
         self.unique_columns = self.get_unique_columns()

--- a/data_diff/tracking.py
+++ b/data_diff/tracking.py
@@ -56,6 +56,11 @@ def set_entrypoint_name(s):
     global entrypoint_name
     entrypoint_name = s
 
+dbt_user_id = None
+
+def set_dbt_user_id(s):
+    global dbt_user_id
+    dbt_user_id = s
 
 def get_anonymous_id():
     global g_anonymous_id
@@ -78,6 +83,7 @@ def create_start_event_json(diff_options: Dict[str, Any]):
             "diff_options": diff_options,
             "data_diff_version:": __version__,
             "entrypoint_name": entrypoint_name,
+            "dbt_user_id": dbt_user_id,
         },
     }
 
@@ -112,6 +118,7 @@ def create_end_event_json(
             "entrypoint_name": entrypoint_name,
             "is_cloud": is_cloud,
             "diff_id": diff_id,
+            "dbt_user_id": dbt_user_id,
         },
     }
 


### PR DESCRIPTION
Adding dbt's user ID to tracking. 


Successful dev event for dbt-CLI
<img width="1178" alt="Screen Shot 2023-03-23 at 10 03 38 AM" src="https://user-images.githubusercontent.com/40182913/227287548-f9192157-0387-4bb9-afe0-b33f3b229974.png">

successful dbt cloud event:
<img width="1175" alt="Screen Shot 2023-03-23 at 10 15 50 AM" src="https://user-images.githubusercontent.com/40182913/227287537-7cb03757-94cc-4a9f-a5b0-d249eb8dcdfc.png">

Non-dbt event showing null as expected:
<img width="1185" alt="Screen Shot 2023-03-23 at 10 03 03 AM" src="https://user-images.githubusercontent.com/40182913/227287556-d5d14cf0-6db2-4b4f-98ff-3035a3dee038.png">

