### PR TITLE
Various improvements and features

### DIFF
--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -81,7 +81,9 @@ def diff_tables(
     # Maximum number of rows to write when materializing, per thread. (joindiff only)
     table_write_limit: int = TABLE_WRITE_LIMIT,
 
-    hash_query_type: str = None
+    hash_query_type: str = None,
+    # Optimizer hints for Select queries
+    optimizer_hints: Optional[str] = None
 ) -> Iterator:
     """Finds the diff between table1 and table2.
 
@@ -111,10 +113,11 @@ def diff_tables(
         materialize_all_rows (bool): Materialize every row, not just those that are different. (used for `JOINDIFF`. default: False)
         table_write_limit (int): Maximum number of rows to write when materializing, per thread.
         hash_query_type (str): multi, or grouped
+        optimizer_hints (Optional[str]): optimizer hints for SELECT queries
 
     Note:
         The following parameters are used to override the corresponding attributes of the given :class:`TableSegment` instances:
-        `key_columns`, `update_column`, `extra_columns`, `min_key`, `max_key`, `where`.
+        `key_columns`, `update_column`, `extra_columns`, `min_key`, `max_key`, `where`, `optimizer_hints`.
         If different values are needed per table, it's possible to omit them here, and instead set
         them directly when creating each :class:`TableSegment`.
 
@@ -144,7 +147,8 @@ def diff_tables(
             min_update=min_update,
             max_update=max_update,
             where=where,
-            hash_query_type=hash_query_type
+            hash_query_type=hash_query_type,
+            optimizer_hints=optimizer_hints
         ).items()
         if v is not None
     }

--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -6,7 +6,7 @@ from sqeleton.abcs import DbTime, DbPath
 from .tracking import disable_tracking
 from .databases import connect
 from .diff_tables import Algorithm
-from .hashdiff_tables import HashDiffer, DEFAULT_BISECTION_THRESHOLD, DEFAULT_BISECTION_FACTOR, SinglePassHashDiffer
+from .hashdiff_tables import HashDiffer, DEFAULT_BISECTION_THRESHOLD, DEFAULT_BISECTION_FACTOR, GroupingHashDiffer
 from .joindiff_tables import JoinDiffer, TABLE_WRITE_LIMIT
 from .table_segment import TableSegment
 from .utils import eval_name_template, Vector
@@ -171,7 +171,7 @@ def diff_tables(
             )
         else:
             logging.info('Diffing with HASHDIFF grouped query')
-            differ = SinglePassHashDiffer(
+            differ = GroupingHashDiffer(
                 bisection_factor=bisection_factor,
                 bisection_threshold=bisection_threshold,
                 threaded=threaded,

--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -83,7 +83,7 @@ def diff_tables(
 
     hash_query_type: str = None,
     # Optimizer hints for Select queries
-    optimizer_hints: Optional[str] = None
+    optimizer_hints: Optional[str] = None,
 ) -> Iterator:
     """Finds the diff between table1 and table2.
 

--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -5,7 +5,7 @@ from sqeleton.abcs import DbTime, DbPath
 
 from .tracking import disable_tracking
 from .databases import connect
-from .diff_tables import Algorithm
+from .diff_tables import Algorithm, TableDiffer
 from .hashdiff_tables import HashDiffer, DEFAULT_BISECTION_THRESHOLD, DEFAULT_BISECTION_FACTOR, GroupingHashDiffer
 from .joindiff_tables import JoinDiffer, TABLE_WRITE_LIMIT
 from .table_segment import TableSegment
@@ -84,7 +84,7 @@ def diff_tables(
     hash_query_type: str = None,
     # Optimizer hints for Select queries
     optimizer_hints: Optional[str] = None,
-) -> Iterator:
+) -> tuple[TableDiffer, Iterator]:
     """Finds the diff between table1 and table2.
 
     Parameters:
@@ -192,4 +192,4 @@ def diff_tables(
     else:
         raise ValueError(f"Unknown algorithm: {algorithm}")
 
-    return differ.diff_tables(*segments)
+    return differ, differ.diff_tables(*segments)

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -147,7 +147,7 @@ class DiffResultWrapper:
             string_output += f"Updated Rows: {diff_stats.diff_by_sign['!']}\n"
             string_output += f"Unchanged Rows: {diff_stats.unchanged}\n\n"
 
-            string_output += f"Values Updated:"
+            string_output += "Values Updated:"
 
             for k, v in diff_stats.extra_column_diffs.items():
                 string_output += f"\n{k}: {v}"

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -99,7 +99,7 @@ class DiffResultWrapper:
     def _get_stats(self, is_dbt: bool = False) -> DiffStats:
         list(self)  # Consume the iterator into result_list, if we haven't already
 
-        key_columns = self.info_tree.info.tables[0].key_columns
+        key_columns = self.info_tree.info.tables[0].key_indices
         len_key_columns = len(key_columns)
         diff_by_key = {}
         extra_column_diffs = None

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -406,18 +406,5 @@ class GroupingHashDiffer(HashDiffer):
         ti = ThreadedYielder(self.max_threadpool_size)
         # Bisect (split) the table into segments, and diff them recursively.
         ti.submit(self._bisect_and_diff_segments, ti, table1, table2, info_tree)
-        # self._bisect_and_diff_segments(ti, table1, table2, info_tree)
-
-        # TODO: I don't think we need to do this part since we already got min/max keys for both tables up front
-        # # Now we check for the second min-max, to diff the portions we "missed".
-        # min_key2, max_key2 = self._parse_key_range_result(key_type, next(key_ranges))
-
-        # if min_key2 < min_key1:
-        #     pre_tables = [t.new(min_key=min_key2, max_key=min_key1) for t in (table1, table2)]
-        #     ti.submit(self._bisect_and_diff_segments, ti, *pre_tables, info_tree)
-
-        # if max_key2 > max_key1:
-        #     post_tables = [t.new(min_key=max_key1, max_key=max_key2) for t in (table1, table2)]
-        #     ti.submit(self._bisect_and_diff_segments, ti, *post_tables, info_tree)
 
         return ti

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -92,6 +92,13 @@ class HashDiffer(TableDiffer):
             # Update schemas to minimal mutual precision
             col1 = table1._schema[c1]
             col2 = table2._schema[c2]
+
+            # if user passed specialized conversions for either column, skip validation
+            if any(c in table1.col_conversions for c in [c1.lower(), c1.upper()]):
+                continue
+            if any(c in table2.col_conversions for c in [c2.lower(), c2.upper()]):
+                continue
+
             if isinstance(col1, PrecisionType):
                 if not isinstance(col2, PrecisionType):
                     raise TypeError(f"Incompatible types for column '{c1}':  {col1} <-> {col2}")

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -80,6 +80,8 @@ class HashDiffer(TableDiffer):
         if self.bisection_factor < 2:
             raise ValueError("Must have at least two segments per iteration (i.e. bisection_factor >= 2)")
 
+        super().__post_init__()
+        
     def _validate_and_adjust_columns(self, table1, table2):
         for c1, c2 in safezip(table1.relevant_columns, table2.relevant_columns):
             if c1 not in table1._schema:
@@ -410,8 +412,8 @@ class GroupingHashDiffer(HashDiffer):
             f"size: table1 <= {table1.approximate_size()}, table2 <= {table2.approximate_size()}"
         )
 
-        ti = ThreadedYielder(self.max_threadpool_size)
+        self.ti = ThreadedYielder(self.max_threadpool_size)
         # Bisect (split) the table into segments, and diff them recursively.
-        ti.submit(self._bisect_and_diff_segments, ti, table1, table2, info_tree)
+        self.ti.submit(self._bisect_and_diff_segments, self.ti, table1, table2, info_tree)
 
-        return ti
+        return self.ti

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -1,13 +1,15 @@
+from functools import partial
 import os
 from numbers import Number
 import logging
 from collections import defaultdict
-from typing import Iterator
-from operator import attrgetter
+import sys
+from typing import Iterator, List
+from operator import attrgetter, methodcaller
 
 from runtype import dataclass
 
-from sqeleton.abcs import ColType_UUID, NumericType, PrecisionType, StringType, Boolean
+from sqeleton.abcs import ColType_UUID, NumericType, PrecisionType, StringType, Boolean, IKey
 
 from .info_tree import InfoTree
 from .utils import safezip
@@ -182,6 +184,8 @@ class HashDiffer(TableDiffer):
         level=0,
         max_rows=None,
     ):
+        logging.info('HashDiffer._bisect_and_diff_segments')
+
         assert table1.is_bounded and table2.is_bounded
 
         max_space_size = max(table1.approximate_size(), table2.approximate_size())
@@ -204,3 +208,186 @@ class HashDiffer(TableDiffer):
             return diff
 
         return super()._bisect_and_diff_segments(ti, table1, table2, info_tree, level, max_rows)
+
+
+@dataclass
+class SinglePassHashDiffer(HashDiffer):
+
+    stats: dict = {}
+
+    def _diff_segments(
+        self,
+        ti: ThreadedYielder,
+        segment1: TableSegment,
+        segment2: TableSegment,
+        result1: List,
+        result2: List,
+        info_tree: InfoTree,
+        max_rows: int,
+        level=0,
+        segment_index=None,
+        segment_count=None,
+    ):
+        _, count1, checksum1 = result1
+        _, count2, checksum2 = result2
+
+        info_tree.info.rowcounts = {1: count1, 2: count2}
+
+        if count1 == 0 and count2 == 0:
+            logger.debug(
+                "Uneven distribution of keys detected in segment %s..%s (big gaps in the key column). "
+                "For better performance, we recommend to increase the bisection-threshold.",
+                segment1.min_key,
+                segment1.max_key,
+            )
+            assert checksum1 is None and checksum2 is None
+            info_tree.info.is_diff = False
+            return
+
+        if checksum1 == checksum2:
+            info_tree.info.is_diff = False
+            return
+
+        info_tree.info.is_diff = True
+        return self._bisect_and_diff_segments(ti, segment1, segment2, info_tree, level=level, max_rows=max(count1, count2))
+
+    def _bisect_and_diff_segments(
+        self,
+        ti: ThreadedYielder,
+        table1: TableSegment,
+        table2: TableSegment,
+        info_tree: InfoTree,
+        level=0,
+        max_rows=None,
+    ):
+        logging.info('SinglePassHashDiffer._bisect_and_diff_segments')
+
+        assert table1.is_bounded and table2.is_bounded
+
+        max_space_size = max(table1.approximate_size(), table2.approximate_size())
+        # logging.info(f'max_space_size: {max_space_size}')
+        if max_rows is None:
+            # We can be sure that row_count <= max_rows iff the table key is unique
+            max_rows = max_space_size
+            info_tree.info.max_rows = max_rows
+
+        # If count is below the threshold, just download and compare the columns locally
+        # This saves time, as bisection speed is limited by ping and query performance.
+        # NOTE: Instead of using max_space_size for 2nd comparison, using max_rows since its the ACTUAL count of rows
+        #       as retreived from the last query. This especially important when dealing with a composite PK table 
+        #       because the approximate_size is likely a gross underestimation.
+        if max_rows < self.bisection_threshold or max_rows < self.bisection_factor * 2:
+            logging.info('get_values')
+            rows1, rows2 = self._threaded_call("get_values", [table1, table2])
+            diff = list(diff_sets(rows1, rows2))
+
+            info_tree.info.set_diff(diff)
+            info_tree.info.rowcounts = {1: len(rows1), 2: len(rows2)}
+
+            logger.info(". " * level + f"Diff found {len(diff)} different rows.")
+            self.stats["rows_downloaded"] = self.stats.get("rows_downloaded", 0) + max(len(rows1), len(rows2))
+            return diff
+
+        # Choose evenly spaced checkpoints (according to min_key and max_key)
+        biggest_table = max(table1, table2, key=methodcaller("approximate_size"))
+        checkpoints = biggest_table.choose_checkpoints(self.bisection_factor - 1)
+        # logging.info(f'checkpoints: {checkpoints}')
+
+        if table1.hash_query_type == 'multi' and table2.hash_query_type == 'multi':
+            raise ValueError('At least 1 table must use the groupby hash query type')
+
+        segmented1 = table1.segment_by_checkpoints(checkpoints)
+        segmented2 = table2.segment_by_checkpoints(checkpoints)
+
+        bg_funcs = {'t1': [], 't2': []}
+        if table1.hash_query_type == 'multi':
+            bg_funcs['t1'] = [seg.count_and_checksum for seg in segmented1]
+        else:
+            bg_funcs['t1'] = [partial(table1.count_and_checksum_by_group, checkpoints, self.bisection_factor, max_rows)]
+
+        if table2.hash_query_type == 'multi':
+            bg_funcs['t2'] = [seg.count_and_checksum for seg in segmented2]
+        else:
+            bg_funcs['t2'] = [partial(table2.count_and_checksum_by_group, checkpoints, self.bisection_factor, max_rows)]
+
+        logging.info(f'Running in background: {len(bg_funcs["t1"]) + len(bg_funcs["t2"])}')
+
+        def print_res(label, res):
+            out = [str(r) for r in res]
+            logging.info('{}\n{}'.format(label, "\n".join(out)))
+        
+        # wait for all queries to complete
+        all_results = ti._submit_and_block(*bg_funcs['t1'], *bg_funcs['t2'], priority=level)
+        table1_res = all_results[:len(bg_funcs['t1'])]
+        table2_res = all_results[len(bg_funcs['t1']):]
+
+        if len(bg_funcs['t1']) == 1:
+            table1_res = table1_res[0]
+        
+        if len(bg_funcs['t2']) == 1:
+            table2_res = table2_res[0]
+
+        print_res('table1_res', table1_res)
+        print_res('table2_res', table2_res)
+
+        # compare results for each segment in parallel
+        for idx, (res1, res2, seg1, seg2) in enumerate(zip(table1_res, table2_res, segmented1, segmented2)):
+            ti.submit(self._diff_segments, ti, seg1, seg2, res1, res2, info_tree, max_rows, level + 1, idx+1, len(segmented1)) #), priority=level)
+
+
+    def _bisect_and_diff_tables(self, table1, table2, info_tree):
+        logging.info('SinglePassHashDiffer._bisect_and_diff_tables')
+        if len(table1.key_columns) > 1:
+            raise NotImplementedError("Composite key not supported yet!")
+        if len(table2.key_columns) > 1:
+            raise NotImplementedError("Composite key not supported yet!")
+        if len(table1.key_columns) != len(table2.key_columns):
+            raise ValueError("Tables should have an equivalent number of key columns!")
+        (key1,) = table1.key_columns
+        (key2,) = table2.key_columns
+
+        key_type = table1._schema[key1]
+        key_type2 = table2._schema[key2]
+        if not isinstance(key_type, IKey):
+            raise NotImplementedError(f"Cannot use column of type {key_type} as a key")
+        if not isinstance(key_type2, IKey):
+            raise NotImplementedError(f"Cannot use column of type {key_type2} as a key")
+        if key_type.python_type is not key_type2.python_type:
+            raise TypeError(f"Incompatible key types: {key_type} and {key_type2}")
+
+        # Query min/max values
+        key_ranges = self._threaded_call_as_completed("query_key_range", [table1, table2])
+        # key_ranges = (kr for kr in [((2009), (2543202)), ((2009), (2543202))])
+
+        # Wait for both
+        min_key1, max_key1 = self._parse_key_range_result(key_type, next(key_ranges))
+        min_key2, max_key2 = self._parse_key_range_result(key_type, next(key_ranges))
+
+        min_key = min(min_key1, min_key2)
+        max_key = max(max_key1, max_key2)
+
+        table1, table2 = [t.new(min_key=min_key, max_key=max_key) for t in (table1, table2)]
+
+        logger.info(
+            f"Diffing segments at key-range: {table1.min_key}..{table2.max_key}. "
+            f"size: table1 <= {table1.approximate_size()}, table2 <= {table2.approximate_size()}"
+        )
+
+        ti = ThreadedYielder(self.max_threadpool_size)
+        # Bisect (split) the table into segments, and diff them recursively.
+        ti.submit(self._bisect_and_diff_segments, ti, table1, table2, info_tree)
+        # self._bisect_and_diff_segments(ti, table1, table2, info_tree)
+
+        # TODO: I don't think we need to do this part since we already got min/max keys for both tables up front
+        # # Now we check for the second min-max, to diff the portions we "missed".
+        # min_key2, max_key2 = self._parse_key_range_result(key_type, next(key_ranges))
+
+        # if min_key2 < min_key1:
+        #     pre_tables = [t.new(min_key=min_key2, max_key=min_key1) for t in (table1, table2)]
+        #     ti.submit(self._bisect_and_diff_segments, ti, *pre_tables, info_tree)
+
+        # if max_key2 > max_key1:
+        #     post_tables = [t.new(min_key=max_key1, max_key=max_key2) for t in (table1, table2)]
+        #     ti.submit(self._bisect_and_diff_segments, ti, *post_tables, info_tree)
+
+        return ti

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -303,12 +303,12 @@ class SinglePassHashDiffer(HashDiffer):
         if table1.hash_query_type == 'multi':
             bg_funcs['t1'] = [seg.count_and_checksum for seg in segmented1]
         else:
-            bg_funcs['t1'] = [partial(table1.count_and_checksum_by_group, checkpoints, self.bisection_factor, max_rows)]
+            bg_funcs['t1'] = [partial(table1.count_and_checksum_by_group, checkpoints[0], self.bisection_factor, max_rows)]
 
         if table2.hash_query_type == 'multi':
             bg_funcs['t2'] = [seg.count_and_checksum for seg in segmented2]
         else:
-            bg_funcs['t2'] = [partial(table2.count_and_checksum_by_group, checkpoints, self.bisection_factor, max_rows)]
+            bg_funcs['t2'] = [partial(table2.count_and_checksum_by_group, checkpoints[0], self.bisection_factor, max_rows)]
 
         logging.info(f'Running in background: {len(bg_funcs["t1"]) + len(bg_funcs["t2"])}')
 

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -152,7 +152,7 @@ class HashDiffer(TableDiffer):
             if max_rows < self.bisection_threshold:
                 return self._bisect_and_diff_segments(ti, table1, table2, info_tree, level=level, max_rows=max_rows)
 
-        (count1, checksum1), (count2, checksum2) = self._threaded_call("count_and_checksum", [table1, table2])
+        (_, count1, checksum1), (_, count2, checksum2) = self._threaded_call("count_and_checksum", [table1, table2])
 
         assert not info_tree.info.rowcounts
         info_tree.info.rowcounts = {1: count1, 2: count2}

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -211,7 +211,7 @@ class HashDiffer(TableDiffer):
 
 
 @dataclass
-class SinglePassHashDiffer(HashDiffer):
+class GroupingHashDiffer(HashDiffer):
 
     stats: dict = {}
 

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -260,7 +260,6 @@ class GroupingHashDiffer(HashDiffer):
         level=0,
         max_rows=None,
     ):
-        logging.info('SinglePassHashDiffer._bisect_and_diff_segments')
 
         assert table1.is_bounded and table2.is_bounded
 

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -303,12 +303,12 @@ class SinglePassHashDiffer(HashDiffer):
         if table1.hash_query_type == 'multi':
             bg_funcs['t1'] = [seg.count_and_checksum for seg in segmented1]
         else:
-            bg_funcs['t1'] = [partial(table1.count_and_checksum_by_group, checkpoints[0], self.bisection_factor, max_rows)]
+            bg_funcs['t1'] = [partial(table1.count_and_checksum_by_group, checkpoints[0], self.bisection_factor, optimizer_hints=(level == 0))]
 
         if table2.hash_query_type == 'multi':
             bg_funcs['t2'] = [seg.count_and_checksum for seg in segmented2]
         else:
-            bg_funcs['t2'] = [partial(table2.count_and_checksum_by_group, checkpoints[0], self.bisection_factor, max_rows)]
+            bg_funcs['t2'] = [partial(table2.count_and_checksum_by_group, checkpoints[0], self.bisection_factor, optimizer_hints=(level == 0))]
 
         logging.info(f'Running in background: {len(bg_funcs["t1"]) + len(bg_funcs["t2"])}')
 

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -332,7 +332,8 @@ class SinglePassHashDiffer(HashDiffer):
 
         # compare results for each segment in parallel
         for idx, (res1, res2, seg1, seg2) in enumerate(zip(table1_res, table2_res, segmented1, segmented2)):
-            ti.submit(self._diff_segments, ti, seg1, seg2, res1, res2, info_tree, max_rows, level + 1, idx+1, len(segmented1)) #), priority=level)
+            info_node = info_tree.add_node(seg1, seg2, max_rows=max_rows)
+            ti.submit(self._diff_segments, ti, seg1, seg2, res1, res2, info_node, max_rows, level + 1, idx+1, len(segmented1)) #), priority=level)
 
     def _resolve_key_range(self, key_range_res, usr_key_range):
         key_range_res = list(key_range_res)

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -6,8 +6,8 @@ from itertools import product
 
 from runtype import dataclass
 
-from .utils import safezip, Vector
-from sqeleton.utils import ArithString, split_space
+from .utils import safezip, Vector, split_space
+from sqeleton.utils import ArithString
 from sqeleton.databases import Database, DbPath, DbKey, DbTime
 from sqeleton.schema import Schema, create_schema
 from sqeleton.queries import Count, Checksum, SKIP, table, this, Expr, min_, max_, Code, Compiler

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -224,7 +224,7 @@ class TableSegment:
 
         if self.max_key is not None:
             assert min_key < self.max_key
-            assert max_key <= self.max_key
+            assert max_key <= self.max_key, (max_key, self.max_key)
 
         return self.replace(min_key=min_key, max_key=max_key)
 
@@ -247,8 +247,6 @@ class TableSegment:
 
     def count_and_checksum(self) -> Tuple[int, int]:
         """Count and checksum the rows in the segment, in one pass."""
-        logging.info('count_and_checksum')
-        time.sleep(1)
 
         start = time.monotonic()
         q = self.make_select().select(
@@ -271,9 +269,6 @@ class TableSegment:
     def count_and_checksum_by_group(self, checkpoints: List, bisection_factor: int, optimizer_hints=False) -> Tuple[Tuple[int, int]]:
         """Count and checksum each group"""
 
-        # TODO: REMOVE
-        logging.info('count_and_checksum_by_group')
-        time.sleep(4)
         """
         If group_by col is PK:
             if PK is num: use GROUP BY FLOOR(div_factor)

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -266,7 +266,7 @@ class TableSegment:
         if count:
             assert checksum, (count, checksum)
         # return count or 0, int(checksum) if count else None
-        return f'{self.min_key} - {self.max_key}', count or 0, int(checksum) if count else None
+        return self.min_key, count or 0, int(checksum) if count else None
 
     def count_and_checksum_by_group(self, checkpoints: List, bisection_factor: int, optimizer_hints=False) -> Tuple[Tuple[int, int]]:
         """Count and checksum each group"""

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -241,9 +241,7 @@ class TableSegment:
 
         start = time.monotonic()
         q = self.make_select().select(
-            Count(),
-            Checksum(self._relevant_columns_repr),
-            optimizer_hints=self.optimizer_hints
+            Count(), Checksum(self._relevant_columns_repr), optimizer_hints=self.optimizer_hints
         )
         count, checksum = self.database.query(q, tuple)
         duration = time.monotonic() - start

--- a/data_diff/thread_utils.py
+++ b/data_diff/thread_utils.py
@@ -82,3 +82,6 @@ class ThreadedYielder(Iterable):
                 self._futures.popleft()
             else:
                 sleep(0.001)
+
+    def abort(self) -> None:
+        self._pool.shutdown(wait=True, cancel_futures=True)

--- a/data_diff/thread_utils.py
+++ b/data_diff/thread_utils.py
@@ -62,6 +62,10 @@ class ThreadedYielder(Iterable):
     def submit(self, fn: Callable, *args, priority: int = 0, **kwargs):
         self._futures.append(self._pool.submit(self._worker, fn, *args, priority=priority, **kwargs))
 
+    def _submit_and_block(self, *funcs, priority):
+        futures = [self._pool.submit(fn, priority=priority) for fn in funcs if fn is not None]
+        return [f.result() for f in futures]
+
     def __iter__(self) -> Iterator:
         while True:
             if self._exception:

--- a/data_diff/tracking.py
+++ b/data_diff/tracking.py
@@ -49,7 +49,7 @@ def disable_tracking():
 
 
 def is_tracking_enabled():
-    return g_tracking_enabled
+    return False
 
 
 def set_entrypoint_name(s):

--- a/data_diff/utils.py
+++ b/data_diff/utils.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Dict, Iterable, Sequence
+from typing import Dict, Iterable, List, Sequence
 from urllib.parse import urlparse
 import operator
 import threading
@@ -85,6 +85,13 @@ def get_from_dict_with_raise(dictionary: Dict, key: str, error_message: str):
         raise ValueError(error_message)
     return result
 
+def split_space(start, end, count) -> List[int]:
+    size = end - start
+    assert count <= size, (count, size)
+
+     # NOTE: I copied this in from sqeleton to avoid having to fork 2 libraries,
+     # and modified to include 1 additional checkpoint for compat with group_by algo
+    return list(range(start, end, (size + 1) // (count + 1)))[1:]
 
 class Vector(tuple):
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -540,10 +540,10 @@ files = [
 cffi = ">=1.12"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx_rtd_theme"]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
-sdist = ["setuptools_rust (>=0.11.4)"]
+sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
 
@@ -1006,14 +1006,14 @@ files = [
 ]
 
 [package.extras]
-all = ["Jinja2", "brotli", "cython", "execnet (>=1.0.9)", "pytest (>4.0)", "pytest-cov (>=2.6)", "pyzmq", "redis", "sqlalchemy"]
+all = ["Jinja2", "brotli", "cython", "execnet (>=1.0.9)", "mock", "pytest", "pytest-cov (<2.6)", "pyzmq", "redis", "sqlalchemy"]
 compression = ["brotli"]
-dev = ["cython", "pytest (>4.0)", "pytest-cov (>=2.6)"]
+dev = ["cython", "mock", "pytest", "pytest-cov (<2.6)"]
 execnet = ["execnet (>=1.0.9)"]
 jinja = ["Jinja2"]
 redis = ["redis"]
 sqlalchemy = ["sqlalchemy"]
-test = ["pytest (>4.0)", "pytest-cov (>=2.6)"]
+test = ["mock", "pytest", "pytest-cov (<2.6)"]
 zmq = ["pyzmq"]
 
 [[package]]
@@ -1947,6 +1947,8 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win32.whl", hash = "sha256:f6d3d39611ac2e4f62c3128a9eed45f19a6608670c5a2f4f07f24e8de3441d38"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win_amd64.whl", hash = "sha256:da538167284de58a52109a9b89b8f6a53ff8437dd6dc26d33b57bf6699153122"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4b3a93bb9bc662fc1f99c5c3ea8e623d8b23ad22f861eb6fce9377ac07ad6072"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_12_0_arm64.whl", hash = "sha256:a234a20ae07e8469da311e182e70ef6b199d0fbeb6c6cc2901204dd87fb867e8"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:15910ef4f3e537eea7fe45f8a5d19997479940d9196f357152a09031c5be59f3"},
@@ -2079,28 +2081,34 @@ version = "0.0.7"
 description = "Python library for querying SQL databases"
 category = "main"
 optional = false
-python-versions = ">=3.7,<4.0"
-files = [
-    {file = "sqeleton-0.0.7-py3-none-any.whl", hash = "sha256:9e16deb240e675af3facdd57de0264546507507728cad1f6fdba3922428891f4"},
-    {file = "sqeleton-0.0.7.tar.gz", hash = "sha256:cbfb7f2689ad54b1cb528e67d0954ac1a18ab1f1f757883b62f4e5c9dce0b468"},
-]
+python-versions = "^3.7"
+files = []
+develop = false
 
 [package.dependencies]
-click = ">=8.1,<9.0"
+click = "^8.1"
 dsnparse = "*"
 rich = "*"
-runtype = ">=0.2.6,<0.3.0"
-toml = ">=0.10.2,<0.11.0"
+runtype = "^0.2.6"
+toml = "^0.10.2"
 
 [package.extras]
 clickhouse = ["clickhouse-driver"]
 duckdb = ["duckdb (>=0.7.0,<0.8.0)"]
 mysql = ["mysql-connector-python (==8.0.29)"]
+oracle = []
 postgresql = ["psycopg2"]
 presto = ["presto-python-client"]
 snowflake = ["cryptography", "snowflake-connector-python (>=2.7.2,<3.0.0)"]
 trino = ["trino (>=0.314.0,<0.315.0)"]
 tui = ["textual (>=0.9.1,<0.10.0)", "textual-select"]
+vertica = []
+
+[package.source]
+type = "git"
+url = "git@github.com:RoderickJDunn/sqeleton.git"
+reference = "fa23f08cb10437fee298f9a9f3b446f2e87528a5"
+resolved_reference = "fa23f08cb10437fee298f9a9f3b446f2e87528a5"
 
 [[package]]
 name = "sqlparse"
@@ -2360,4 +2368,4 @@ vertica = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "b59e5640f784541aeffecbbcd755af1d4ddabc9d9538565ecae0fdaf596d9d5c"
+content-hash = "76615cdd56c85e10cf1b371d5c87d8fa463c41fd5d3b89769905005e43c9dbf6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dsnparse = "*"
 click = "^8.1"
 rich = "*"
 toml = "^0.10.2"
-sqeleton = "^0.0.7"
+sqeleton = {git = "git@github.com:RoderickJDunn/sqeleton.git@temp", rev = "fa23f08cb10437fee298f9a9f3b446f2e87528a5"}
 mysql-connector-python = {version="8.0.29", optional=true}
 psycopg2 = {version="*", optional=true}
 snowflake-connector-python = {version="^2.7.2", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dsnparse = "*"
 click = "^8.1"
 rich = "*"
 toml = "^0.10.2"
-sqeleton = {git = "git@github.com:RoderickJDunn/sqeleton.git@temp", rev = "fa23f08cb10437fee298f9a9f3b446f2e87528a5"}
+sqeleton = {git = "git@github.com:RoderickJDunn/sqeleton.git", rev = "fa23f08cb10437fee298f9a9f3b446f2e87528a5"}
 mysql-connector-python = {version="8.0.29", optional=true}
 psycopg2 = {version="*", optional=true}
 snowflake-connector-python = {version="^2.7.2", optional=true}


### PR DESCRIPTION
### Summary
- Support overriding column types
- Added Grouping Hash algorithm to support single-pass hashing on large Oracle tables. 
- Disabled tracking
- Support sorting of results when single column of composite PK is used to find hashing ranges
- Support early abort (allows us to exit if timeout or result limit is reached)
- **Support custom column conversions**

## Supporting custom column conversions
Today data-diff always preprocesses columns in the same way for a given data type. This allows for normalization of columns between databases, so that hash comparisons are valid. 

However, there are some cases where we need to specify custom processing of a column in order to create a hash that can be compared to that of the other database. For example the `xxbrk_daily_price` Oracle table contains several columns of type `number` with no precision or scale specified. Fivetran may choose to replicate such columns to Redshift as strings. Today, for this case data-diff will fail right away due to a column type mismatch (it can't compare numerics with strings).

### Why simple casting doesn't work
- I tried to overcome the above issue by supporting column type overrides, but this feature is inadequate in this case. 
- The Oracle columns contain values with very wide range of scales - eg. values of both `1` and `99.01234567890123456789012345678901234567` are possible (that's a scale of 38).
- Those values also exist in Redshift, but they are strings
- If I treat both columns as numeric(38,10), most comparisons pass, but many fail due to minute differences caused by rounding. In Oracle, casting to number(38,10) will yield a rounded number, but in Redshift casting the string to numeric(38,10) will truncate the number.
- If I treat both columns as strings, this similarly fails because Oracle implicitly rounds values before casting to varchar.  

### Solution
- Custom processing of columns allows us to TRUNCATE the oracle values, and thus prevent the implicit rounding from occurring. In summary:
  - Oracle columns are TRUNCATED to a scale of 10, then converted to a string with a normalized format
  - Redshift columns are cast to numeric(38,10), then converted to a string with the same normalized format