### PR TITLE
cloud api token flow

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -232,7 +232,7 @@ def _cloud_diff(diff_vars: DiffVars) -> None:
             webbrowser.open(f"{datafold_host}/login?next={datafold_host}/users/me")
             return
         else:
-            raise ValueError('Cannot diff because the API key is not provided')
+            raise ValueError("Cannot diff because the API key is not provided")
 
     if diff_vars.datasource_id is None:
         raise ValueError(

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -269,7 +269,6 @@ def _cloud_diff(diff_vars: DiffVars) -> None:
         response.raise_for_status()
         data = response.json()
         diff_id = data["id"]
-        # TODO in future we should support self hosted datafold
         diff_url = f"{datafold_host}/datadiffs/{diff_id}/overview"
         rich.print(
             "[red]"

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -1,7 +1,9 @@
 import json
 import os
 import time
+import webbrowser
 import rich
+from rich.prompt import Confirm
 
 from collections import defaultdict
 from dataclasses import dataclass
@@ -220,16 +222,24 @@ def _local_diff(diff_vars: DiffVars) -> None:
 
 
 def _cloud_diff(diff_vars: DiffVars) -> None:
+    datafold_host = os.environ.get("DATAFOLD_HOST", "https://app.datafold.com").rstrip("/")
     api_key = os.environ.get("DATAFOLD_API_KEY")
+    rich.print(f"Cloud datafold host: {datafold_host}")
+    if not api_key:
+        rich.print("[red]API key not found, add it as an environment variable called DATAFOLD_API_KEY.")
+        yes_or_no = Confirm.ask("Would you like to generate a new API key?")
+        if yes_or_no:
+            webbrowser.open(f"{datafold_host}/login?next={datafold_host}/users/me")
+            return
+        else:
+            raise ValueError('Cannot diff because the API key is not provided')
 
     if diff_vars.datasource_id is None:
         raise ValueError(
             "Datasource ID not found, include it as a dbt variable in the dbt_project.yml. \nvars:\n data_diff:\n   datasource_id: 1234"
         )
-    if api_key is None:
-        raise ValueError("API key not found, add it as an environment variable called DATAFOLD_API_KEY.")
 
-    url = "https://app.datafold.com/api/v1/datadiffs"
+    url = f"{datafold_host}/api/v1/datadiffs"
 
     payload = {
         "data_source1_id": diff_vars.datasource_id,
@@ -256,7 +266,7 @@ def _cloud_diff(diff_vars: DiffVars) -> None:
         data = response.json()
         diff_id = data["id"]
         # TODO in future we should support self hosted datafold
-        diff_url = f"https://app.datafold.com/datadiffs/{diff_id}/overview"
+        diff_url = f"{datafold_host}/datadiffs/{diff_id}/overview"
         rich.print(
             "[red]"
             + ".".join(diff_vars.prod_path)

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -222,9 +222,13 @@ def _local_diff(diff_vars: DiffVars) -> None:
 
 
 def _cloud_diff(diff_vars: DiffVars) -> None:
-    datafold_host = os.environ.get("DATAFOLD_HOST", "https://app.datafold.com").rstrip("/")
-    api_key = os.environ.get("DATAFOLD_API_KEY")
+    datafold_host = os.environ.get("DATAFOLD_HOST")
+    if datafold_host is None:
+        datafold_host = "https://app.datafold.com"
+    datafold_host = datafold_host.rstrip("/")
     rich.print(f"Cloud datafold host: {datafold_host}")
+
+    api_key = os.environ.get("DATAFOLD_API_KEY")
     if not api_key:
         rich.print("[red]API key not found, add it as an environment variable called DATAFOLD_API_KEY.")
         yes_or_no = Confirm.ask("Would you like to generate a new API key?")

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -153,7 +153,6 @@ class DiffResultWrapper:
                 string_output += f"\n{k}: {v}"
 
         else:
-
             string_output = ""
             string_output += f"{diff_stats.table1_count} rows in table A\n"
             string_output += f"{diff_stats.table2_count} rows in table B\n"

--- a/data_diff/joindiff_tables.py
+++ b/data_diff/joindiff_tables.py
@@ -201,7 +201,6 @@ class JoinDiffer(TableDiffer):
             if self.materialize_to_table
             else None,
         ):
-
             assert len(a_cols) == len(b_cols)
             logger.debug("Querying for different rows")
             diff = db.query(diff_rows, list)

--- a/data_diff/tracking.py
+++ b/data_diff/tracking.py
@@ -56,11 +56,14 @@ def set_entrypoint_name(s):
     global entrypoint_name
     entrypoint_name = s
 
+
 dbt_user_id = None
+
 
 def set_dbt_user_id(s):
     global dbt_user_id
     dbt_user_id = s
+
 
 def get_anonymous_id():
     global g_anonymous_id


### PR DESCRIPTION
Add an option of generating of a Datafold API key to interact with a datafold cloud.

If the key is not provided, it is suggested to a user to generate it redirecting to a corresponding datafold cloud page.
Also add an opportunity to set a datafold host (by default it is our cloud url https://app.datafold.com)