### PR TITLE
Cloud diffs in progress

### DIFF
--- a/data_diff/cloud/datafold_api.py
+++ b/data_diff/cloud/datafold_api.py
@@ -6,6 +6,9 @@ from typing import Any, Dict, List, Optional, Type, TypeVar, Tuple
 import pydantic
 import requests
 
+from ..utils import getLogger
+
+logger = getLogger(__name__)
 
 Self = TypeVar("Self", bound=pydantic.BaseModel)
 
@@ -216,11 +219,12 @@ class DatafoldAPI:
         summary_results = None
         start_time = time.monotonic()
         sleep_interval = 5  # starts at 5 sec
-        max_sleep_interval = 60
+        max_sleep_interval = 30
         max_wait_time = 300
 
         diff_url = f"{self.host}/datadiffs/{diff_id}/overview"
         while not summary_results:
+            logger.debug(f"Polling: {diff_url}")
             response = self.make_get_request(url=f"api/v1/datadiffs/{diff_id}/summary_results")
             response_json = response.json()
             if response_json["status"] == "success":

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -118,6 +118,7 @@ def dbt_diff(
                     "Datasource ID not found, include it as a dbt variable in the dbt_project.yml. "
                     "\nvars:\n data_diff:\n   datasource_id: 1234"
                 )
+        rich.print("[green][bold]\nDiffs in progress...[/][/]\n")
 
     else:
         dbt_parser.set_connection()
@@ -288,13 +289,13 @@ def _cloud_diff(diff_vars: DiffVars, datasource_id: int, api: DatafoldAPI) -> No
     diff_url = None
     try:
         diff_id = api.create_data_diff(payload=payload)
+        diff_url = f"{api.host}/datadiffs/{diff_id}/overview"
+        rich.print(f"{diff_vars.dev_path[2]}: {diff_url}")
 
         if diff_id is None:
             raise Exception(f"Api response did not contain a diff_id")
 
         diff_results = api.poll_data_diff_results(diff_id)
-
-        diff_url = f"{api.host}/datadiffs/{diff_id}/overview"
 
         rows_added_count = diff_results.pks.exclusives[1]
         rows_removed_count = diff_results.pks.exclusives[0]
@@ -352,4 +353,4 @@ def _cloud_diff(diff_vars: DiffVars, datasource_id: int, api: DatafoldAPI) -> No
 
 
 def _diff_output_base(dev_path: str, prod_path: str) -> str:
-    return f"[green]{prod_path} <> {dev_path}[/] \n"
+    return f"\n[green]{prod_path} <> {dev_path}[/] \n"

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -499,7 +499,7 @@ class TestDbtDiffer(unittest.TestCase):
         _cloud_diff(diff_vars, expected_datasource_id, api=mock_api)
 
         mock_api.create_data_diff.assert_called_once()
-        mock_print.assert_called_once()
+        self.assertEqual(mock_print.call_count, 2)
 
         payload = mock_api.create_data_diff.call_args[1]["payload"]
         self.assertEqual(payload.data_source1_id, expected_datasource_id)
@@ -541,7 +541,7 @@ class TestDbtDiffer(unittest.TestCase):
         mock_initialize_api.assert_called_once()
         mock_cloud_diff.assert_called_once_with(expected_diff_vars, 1, api)
         mock_local_diff.assert_not_called()
-        mock_print.assert_not_called()
+        mock_print.assert_called_once()
 
     @patch("data_diff.dbt._initialize_api")
     @patch("data_diff.dbt._get_diff_vars")
@@ -722,7 +722,7 @@ class TestDbtDiffer(unittest.TestCase):
         mock_dbt_parser_inst.set_connection.assert_not_called()
         mock_cloud_diff.assert_not_called()
         mock_local_diff.assert_not_called()
-        self.assertEqual(mock_print.call_count, 1)
+        self.assertEqual(mock_print.call_count, 2)
 
     @patch("data_diff.dbt._get_diff_vars")
     @patch("data_diff.dbt._local_diff")


### PR DESCRIPTION
It can be unclear when using `--cloud` that "things are happening"

- Add diff links right away and and "in progress" message
- shorten max_sleep_interval on diff results polls to 30 sec

This will make it more clear that "things are happening", allow users to immediately pull up the diff in the UI, and shorten the max time for results to display

https://www.loom.com/share/9d9c504703de44998dca3a282c43b2e7
