### PR TITLE
warn when using recent dbt-core version

### DIFF
--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -28,7 +28,7 @@ MANIFEST_PATH = "target/manifest.json"
 PROJECT_FILE = "dbt_project.yml"
 PROFILES_FILE = "profiles.yml"
 LOWER_DBT_V = "1.0.0"
-UPPER_DBT_V = "1.4.6"
+UPPER_DBT_V = "1.4.7"
 
 
 # https://github.com/dbt-labs/dbt-core/blob/c952d44ec5c2506995fbad75320acbae49125d3d/core/dbt/cli/resolvers.py#L6
@@ -76,10 +76,12 @@ class DbtParser:
         if dbt_version < parse_version("1.3.0"):
             self.profiles_dir = legacy_profiles_dir()
 
-        if dbt_version < parse_version(LOWER_DBT_V) or dbt_version >= parse_version(UPPER_DBT_V):
+        if dbt_version < parse_version(LOWER_DBT_V):
             raise Exception(
                 f"Found dbt: v{dbt_version} Expected the dbt project's version to be >= {LOWER_DBT_V} and < {UPPER_DBT_V}"
             )
+        elif dbt_version >= parse_version(UPPER_DBT_V):
+            logger.warning(f"{dbt_version} is a recent version of dbt and may not be fully tested with data-diff! \nPlease report any issues to https://github.com/datafold/data-diff/issues")
 
         success_models = [x.unique_id for x in run_results_obj.results if x.status.name == "success"]
         models = [self.manifest_obj.nodes.get(x) for x in success_models]

--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -78,7 +78,7 @@ class DbtParser:
 
         if dbt_version < parse_version(LOWER_DBT_V):
             raise Exception(
-                f"Found dbt: v{dbt_version} Expected the dbt project's version to be >= {LOWER_DBT_V} and < {UPPER_DBT_V}"
+                f"Found dbt: v{dbt_version} Expected the dbt project's version to be >= {LOWER_DBT_V}"
             )
         elif dbt_version >= parse_version(UPPER_DBT_V):
             logger.warning(f"{dbt_version} is a recent version of dbt and may not be fully tested with data-diff! \nPlease report any issues to https://github.com/datafold/data-diff/issues")

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -90,22 +90,6 @@ class TestDbtParser(unittest.TestCase):
         self.assertIn("version to be", ex.exception.args[0])
 
     @patch("builtins.open", new_callable=mock_open, read_data="{}")
-    def test_get_models_bad_upper_dbt_version(self, mock_open):
-        mock_self = Mock()
-        mock_self.project_dir = Path()
-        mock_run_results = Mock()
-        mock_self.parse_run_results.return_value = mock_run_results
-        mock_run_results.metadata.dbt_version = "1.5.1"
-
-        with self.assertRaises(Exception) as ex:
-            DbtParser.get_models(mock_self)
-
-        mock_open.assert_called_once_with(Path(RUN_RESULTS_PATH))
-        mock_self.parse_run_results.assert_called_once_with(run_results={})
-        mock_self.parse_manifest.assert_not_called()
-        self.assertIn("version to be", ex.exception.args[0])
-
-    @patch("builtins.open", new_callable=mock_open, read_data="{}")
     def test_get_models_no_success(self, mock_open):
         mock_self = Mock()
         mock_self.project_dir = Path()


### PR DESCRIPTION
Resolves #516 

Warn when using a recent dbt-core version instead of throwing an exception:
![Screenshot 2023-04-20 at 11 44 19 AM](https://user-images.githubusercontent.com/11282254/233447640-c96afb9f-e66e-4fe1-a920-f476c9b0c0b1.png)
