### PR TITLE
add support for two part id

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -161,8 +161,8 @@ def _get_diff_vars(
         prod_qualified_list = [x.upper() for x in [prod_database, prod_schema, model.alias] if x]
         primary_keys = [x.upper() for x in primary_keys]
     else:
-        dev_qualified_list = list(filter(None, [dev_database, dev_schema, model.alias]))
-        prod_qualified_list = list(filter(None, [prod_database, prod_schema, model.alias]))
+        dev_qualified_list = [x for x in [dev_database, dev_schema, model.alias] if x]
+        prod_qualified_list = [x for x in [prod_database, prod_schema, model.alias] if x]
 
     where_filter = None
     if model.meta:

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -618,38 +618,6 @@ class TestDbtDiffer(unittest.TestCase):
     @patch("data_diff.dbt._cloud_diff")
     @patch("data_diff.dbt_parser.DbtParser.__new__")
     @patch("data_diff.dbt.rich.print")
-    def test_diff_no_prod_configs(
-        self, mock_print, mock_dbt_parser, mock_cloud_diff, mock_local_diff, mock_get_diff_vars
-    ):
-        mock_dbt_parser_inst = Mock()
-        mock_dbt_parser.return_value = mock_dbt_parser_inst
-        mock_model = Mock()
-        expected_dbt_vars_dict = {
-            "datasource_id": 1,
-        }
-
-        mock_dbt_parser_inst.get_models.return_value = [mock_model]
-        mock_dbt_parser_inst.get_datadiff_variables.return_value = expected_dbt_vars_dict
-        connection = None
-        threads = None
-        where = "a_string"
-        expected_diff_vars = DiffVars(["dev"], ["prod"], ["pks"], connection, threads, where)
-        mock_get_diff_vars.return_value = expected_diff_vars
-        with self.assertRaises(ValueError):
-            dbt_diff(is_cloud=False)
-
-        mock_dbt_parser_inst.get_models.assert_called_once()
-        mock_dbt_parser_inst.set_connection.assert_called_once()
-        mock_dbt_parser_inst.get_primary_keys.assert_not_called()
-        mock_cloud_diff.assert_not_called()
-        mock_local_diff.assert_not_called()
-        mock_print.assert_not_called()
-
-    @patch("data_diff.dbt._get_diff_vars")
-    @patch("data_diff.dbt._local_diff")
-    @patch("data_diff.dbt._cloud_diff")
-    @patch("data_diff.dbt_parser.DbtParser.__new__")
-    @patch("data_diff.dbt.rich.print")
     def test_diff_only_prod_db(self, mock_print, mock_dbt_parser, mock_cloud_diff, mock_local_diff, mock_get_diff_vars):
         mock_dbt_parser_inst = Mock()
         mock_dbt_parser.return_value = mock_dbt_parser_inst
@@ -696,14 +664,12 @@ class TestDbtDiffer(unittest.TestCase):
         where = "a_string"
         expected_diff_vars = DiffVars(["dev"], ["prod"], ["pks"], connection, threads, where)
         mock_get_diff_vars.return_value = expected_diff_vars
-        with self.assertRaises(ValueError):
-            dbt_diff(is_cloud=False)
+        dbt_diff(is_cloud=False)
 
         mock_dbt_parser_inst.get_models.assert_called_once()
         mock_dbt_parser_inst.set_connection.assert_called_once()
-        mock_dbt_parser_inst.get_primary_keys.assert_not_called()
         mock_cloud_diff.assert_not_called()
-        mock_local_diff.assert_not_called()
+        mock_local_diff.assert_called_once_with(expected_diff_vars)
         mock_print.assert_not_called()
 
     @patch("data_diff.dbt._initialize_api")


### PR DESCRIPTION
Resolves #530

This will also make the `prod_database:` field in dbt_project.yml optional. When that is not included, use the database from the local manifest.json (prod_db == dev_db)

This can be `None` for some dbt adapters like Databricks, so `None` values are filtered out.