### PR TITLE
Hotfix: Correct early return in diffs_are_equiv_jsons not including the set object

### DIFF
--- a/data_diff/utils.py
+++ b/data_diff/utils.py
@@ -155,10 +155,10 @@ def _jsons_equiv(a: str, b: str):
 
 
 def diffs_are_equiv_jsons(diff: list, json_cols: dict):
-    if (len(diff) != 2) or ({diff[0][0], diff[1][0]} != {'+', '-'}):
-        return False
-    match = True
     overriden_diff_cols = set()
+    if (len(diff) != 2) or ({diff[0][0], diff[1][0]} != {'+', '-'}):
+        return False, overriden_diff_cols
+    match = True
     for i, (col_a, col_b) in enumerate(safezip(diff[0][1][1:], diff[1][1][1:])):  # index 0 is extra_columns first elem
         # we only attempt to parse columns of JSONType, but we still need to check if non-json columns don't match
         match = col_a == col_b


### PR DESCRIPTION
#### Problem
Current version is broken, when calling `utils.diffs_are_equiv_jsons`, `hashdiff_tables.diff_sets` is expecting to have always 2 values to unpack and the early return in the function outputs a single boolean.

When adding the warning feature, I forgot to change the early return to match the function's signature.