### PR TITLE
instantiate MACRO_DEBUGGING global for dbt

### DIFF
--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -26,6 +26,7 @@ def import_dbt_dependencies():
     try:
         # ProfileRenderer.render_data() fails without instantiating global flag MACRO_DEBUGGING in dbt-core 1.5
         from dbt.flags import set_flags
+
         set_flags(Namespace(MACRO_DEBUGGING=False))
     except:
         pass

--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -198,7 +198,7 @@ class DbtParser:
             profiles, dbt_profile_var, f"No profile '{dbt_profile_var}' found in '{profiles_path}'."
         )
         # values can contain env_vars
-        rendered_profile = self.ProfileRenderer({'flags':{'DBT_MACRO_DEBUGGING': 0}}).render_data(profile)
+        rendered_profile = self.ProfileRenderer().render_data(profile)
         profile_target = get_from_dict_with_raise(
             rendered_profile, "target", f"No target found in profile '{dbt_profile_var}' in '{profiles_path}'."
         )


### PR DESCRIPTION
Without setting this flag, we're seeing an exception in dbt 1.5

Assuming it will not hurt earlier versions to set it

```
  File "/Users/dan/Library/Caches/pypoetry/virtualenvs/data-diff-gej9eYRL-py3.10/lib/python3.10/site-packages/dbt/clients/jinja.py", line 102, in _compile
    macro_debugging = get_flags().MACRO_DEBUGGING
AttributeError: 'Namespace' object has no attribute 'MACRO_DEBUGGING'
```