### PR TITLE
link to docs.datafold.com for XDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Please reach out on the dbt Slack in [#tools-datafold](https://getdbt.slack.com/
 
 ### Diffing between databases
 
-Check out our [documentation](https://github.com/datafold/data-diff/blob/master/docs/supported-databases.md) if you're looking to compare data across databases (for example, between Postgres and Snowflake).
+Check out our [documentation](https://docs.datafold.com/reference/open_source/cli) if you're looking to compare data across databases (for example, between Postgres and Snowflake).
 
 <br>
 


### PR DESCRIPTION
Clay pointed out that for people who are interested in XDB, this is a more appropriate docs link than the simple list of supported databases.