### PR TITLE
continue --dbt diff when null PKs exist

### DIFF
--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -79,6 +79,8 @@ def diff_tables(
     materialize_all_rows: bool = False,
     # Maximum number of rows to write when materializing, per thread. (joindiff only)
     table_write_limit: int = TABLE_WRITE_LIMIT,
+    # Skips diffing any rows with null keys. (joindiff only)
+    skip_null_keys: bool = False,
 ) -> Iterator:
     """Finds the diff between table1 and table2.
 
@@ -107,6 +109,7 @@ def diff_tables(
         materialize_to_table (Union[str, DbPath], optional): Path of new table to write diff results to. Disabled if not provided. Used for `JOINDIFF`.
         materialize_all_rows (bool): Materialize every row, not just those that are different. (used for `JOINDIFF`. default: False)
         table_write_limit (int): Maximum number of rows to write when materializing, per thread.
+        skip_null_keys (bool): Skips diffing any rows with null PKs (displays a warning if any are null) (used for `JOINDIFF`. default: False)
 
     Note:
         The following parameters are used to override the corresponding attributes of the given :class:`TableSegment` instances:
@@ -168,6 +171,7 @@ def diff_tables(
             materialize_to_table=materialize_to_table,
             materialize_all_rows=materialize_all_rows,
             table_write_limit=table_write_limit,
+            skip_null_keys=skip_null_keys,
         )
     else:
         raise ValueError(f"Unknown algorithm: {algorithm}")

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -228,6 +228,7 @@ def _local_diff(diff_vars: TDiffVars) -> None:
         algorithm=Algorithm.JOINDIFF,
         extra_columns=extra_columns,
         where=diff_vars.where_filter,
+        skip_null_keys=True,
     )
 
     if list(diff):

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -520,6 +520,7 @@ class TestDbtDiffer(unittest.TestCase):
             algorithm=Algorithm.JOINDIFF,
             extra_columns=ANY,
             where=where,
+            skip_null_keys=True,
         )
         self.assertEqual(len(mock_diff_tables.call_args[1]["extra_columns"]), 2)
         self.assertEqual(mock_connect.call_count, 2)
@@ -557,7 +558,13 @@ class TestDbtDiffer(unittest.TestCase):
             _local_diff(diff_vars)
 
         mock_diff_tables.assert_called_once_with(
-            mock_table1, mock_table2, threaded=True, algorithm=Algorithm.JOINDIFF, extra_columns=ANY, where=where
+            mock_table1,
+            mock_table2,
+            threaded=True,
+            algorithm=Algorithm.JOINDIFF,
+            extra_columns=ANY,
+            where=where,
+            skip_null_keys=True,
         )
         self.assertEqual(len(mock_diff_tables.call_args[1]["extra_columns"]), 2)
         self.assertEqual(mock_connect.call_count, 2)

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -550,6 +550,7 @@ class TestDbtDiffer(unittest.TestCase):
             algorithm=Algorithm.JOINDIFF,
             extra_columns=ANY,
             where=where,
+            skip_null_keys=True,
         )
         self.assertEqual(len(mock_diff_tables.call_args[1]["extra_columns"]), 1)
         self.assertEqual(mock_connect.call_count, 2)


### PR DESCRIPTION
Adds a skip_null_keys option to joindiff (default False)

When set to True, instead of throwing an error and exiting the diff, a warning is displayed and the diff continues (row is skipped).

Added for `--dbt` diffs to resolve #527 
![Screenshot 2023-05-17 at 4 21 01 PM](https://github.com/datafold/data-diff/assets/11282254/f90cf08b-1404-44fa-bf59-61464047730b)
