### PR TITLE
add warning when using outdated data-diff version

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -1,29 +1,16 @@
 import os
 import time
 import webbrowser
+from typing import List, Optional, Dict
+import keyring
+
 import pydantic
 import rich
 from rich.prompt import Confirm
 
-from typing import List, Optional, Dict
-from .utils import (
-    dbt_diff_string_template,
-    getLogger,
-    columns_added_template,
-    columns_removed_template,
-    no_differences_template,
-    columns_type_changed_template,
-)
-
-import keyring
-
+from . import connect_to_table, diff_tables, Algorithm
 from .cloud import DatafoldAPI, TCloudApiDataDiff, TCloudApiOrgMeta, get_or_create_data_source
 from .dbt_parser import DbtParser, PROJECT_FILE
-
-
-logger = getLogger(__name__)
-
-
 from .tracking import (
     set_entrypoint_name,
     set_dbt_user_id,
@@ -34,8 +21,19 @@ from .tracking import (
     send_event_json,
     is_tracking_enabled,
 )
-from .utils import run_as_daemon, truncate_error
-from . import connect_to_table, diff_tables, Algorithm
+from .utils import (
+    dbt_diff_string_template,
+    getLogger,
+    columns_added_template,
+    columns_removed_template,
+    no_differences_template,
+    columns_type_changed_template,
+    run_as_daemon,
+    truncate_error,
+    print_version_info,
+)
+
+logger = getLogger(__name__)
 
 
 class TDiffVars(pydantic.BaseModel):
@@ -55,6 +53,7 @@ def dbt_diff(
     is_cloud: bool = False,
     dbt_selection: Optional[str] = None,
 ) -> None:
+    print_version_info()
     diff_threads = []
     set_entrypoint_name("CLI-dbt")
     dbt_parser = DbtParser(profiles_dir_override, project_dir_override)

--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -1,7 +1,6 @@
 from argparse import Namespace
 from collections import defaultdict
 import json
-import os
 from pathlib import Path
 from typing import List, Dict, Tuple, Set, Optional
 import yaml
@@ -12,7 +11,6 @@ from dbt_artifacts_parser.parser import parse_run_results, parse_manifest
 from dbt.config.renderer import ProfileRenderer
 
 from .utils import getLogger, get_from_dict_with_raise
-from .version import __version__
 
 
 logger = getLogger(__name__)
@@ -187,7 +185,6 @@ class DbtParser:
         if not models:
             raise ValueError("Expected > 0 successful models runs from the last dbt command.")
 
-        print(f"Running with data-diff={__version__}\n")
         return models
 
     def get_manifest_obj(self):

--- a/data_diff/utils.py
+++ b/data_diff/utils.py
@@ -6,7 +6,10 @@ from urllib.parse import urlparse
 import operator
 import threading
 from datetime import datetime
+from packaging.version import parse as parse_version
+import requests
 from tabulate import tabulate
+from .version import __version__
 
 
 def safezip(*args):
@@ -188,3 +191,21 @@ def columns_type_changed_template(columns_type_changed) -> str:
 
 def no_differences_template() -> str:
     return "[bold][green]No row differences[/][/]\n"
+
+
+def print_version_info() -> None:
+    base_version_string = f"Running with data-diff={__version__}"
+    logger = getLogger(__name__)
+    latest_version = None
+    try:
+        response = requests.get(url="https://pypi.org/pypi/data-diff/json", timeout=3)
+        response.raise_for_status()
+        response_json = response.json()
+        latest_version = response_json["info"]["version"]
+    except Exception as ex:
+        logger.debug(f"Failed checking version: {ex}")
+
+    if latest_version and parse_version(__version__) < parse_version(latest_version):
+        print(f"{base_version_string} (Update {latest_version} is available!)")
+    else:
+        print(base_version_string)


### PR DESCRIPTION
Adds a message when a new data-diff version is available

Up-to-date:
![Screenshot 2023-05-18 at 4 36 27 PM](https://github.com/datafold/data-diff/assets/11282254/e748d2c1-1ccb-4fc7-a8a3-5d4954be7fe2)

Not up-to-date:
![Screenshot 2023-05-18 at 4 36 47 PM](https://github.com/datafold/data-diff/assets/11282254/26ef708e-820d-4755-abf7-65a62dce692b)
