### PR TITLE
set close reason to not_planned for stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,3 +27,4 @@ jobs:
         stale-pr-label: 'stale'
         close-issue-message: "Although we are closing this issue as stale, it's not gone forever. Issues can be reopened if there is renewed community interest. Just add a comment and it will be reopened for triage."
         close-pr-message: "Although we are closing this pull request as stale, it's not gone forever. PRs can be reopened if there is renewed community interest. Just add a comment and it will be reopened for triage."
+        close-issue-reason: "not_planned"


### PR DESCRIPTION
Stale issues are being closed as "completed" at the moment. Update to "not_planned"

https://github.com/actions/stale#close-issue-reason