### PR TITLE
remove prompt to create API key, send user straight to docs

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -292,16 +292,7 @@ def _initialize_api() -> Optional[DatafoldAPI]:
         rich.print("[red]API key not found. Getting from the keyring service")
         api_key = keyring.get_password("data-diff", "DATAFOLD_API_KEY")
         if not api_key:
-            rich.print("[red]API key not found, add it as an environment variable called DATAFOLD_API_KEY.")
-
-            yes_or_no = Confirm.ask("Would you like to generate a new API key?")
-            if yes_or_no:
-                webbrowser.open(f"{datafold_host}/login?next={datafold_host}/users/me")
-                rich.print('After generating, please, perform in the terminal "export DATAFOLD_API_KEY=<key>"')
-                return None
-            else:
-                raise ValueError("Cannot initialize API because the API key is not provided")
-
+            rich.print("[red]API key not found. Please follow the steps at https://docs.datafold.com/development_testing/cloud to use the --cloud flag.")
     rich.print("Saving the API key to the system keyring service")
     try:
         keyring.set_password("data-diff", "DATAFOLD_API_KEY", api_key)


### PR DESCRIPTION
Currently, if the API key is not found when the `--cloud` flag is used, the user is guided to generate an API key, go through data source creation, etc.

We should instead simply provide them with a link to the instructions for storing an API key and adding the data source id to `dbt_project.yml`: https://docs.datafold.com/development_testing/cloud