### PR TITLE
log improvements and display diff status

### DIFF
--- a/data_diff/cloud/datafold_api.py
+++ b/data_diff/cloud/datafold_api.py
@@ -246,7 +246,7 @@ class DatafoldAPI:
 
         diff_url = f"{self.host}/datadiffs/{diff_id}/overview"
         while not summary_results:
-            logger.debug(f"Polling: {diff_url}")
+            logger.debug("Polling Datafold for results...")
             response = self.make_get_request(url=f"api/v1/datadiffs/{diff_id}/summary_results")
             response_json = response.json()
             if response_json["status"] == "success":

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -274,7 +274,7 @@ class TestDbtDiffer(unittest.TestCase):
 
         mock_initialize_api.assert_called_once()
         mock_api.get_data_source.assert_called_once_with(1)
-        mock_cloud_diff.assert_called_once_with(diff_vars, 1, mock_api, org_meta)
+        mock_cloud_diff.assert_called_once_with(diff_vars, 1, mock_api, org_meta, None)
         mock_local_diff.assert_not_called()
         mock_print.assert_called_once()
 


### PR DESCRIPTION
Improves the `--debug` log readability by using [RichHandler](https://rich.readthedocs.io/en/stable/logging.html). This format is also used without the debug flag for warnings and errors

![Screenshot 2023-06-16 at 10 10 28 AM](https://github.com/datafold/data-diff/assets/11282254/c3993374-f8af-4ace-a003-d9bf430191c6)

Adds a new custom logging handler LogStatusHandler. This is used to display diff status and some detail for local and cloud `--dbt` diffs.

Local dbt diff:
![Screenshot 2023-06-16 at 11 38 14 AM](https://github.com/datafold/data-diff/assets/11282254/0289f471-1524-4a75-8e24-35e5551e9367)

Cloud dbt diff:
Started (it's not ideal doubling some of the info here, but it seems a rich.status.Status can't display a clickable link... otherwise one line would be great per model)
![Screenshot 2023-06-16 at 10 08 13 AM](https://github.com/datafold/data-diff/assets/11282254/54c6a9fc-501b-43d5-bfe1-f09a2a186a0b)
One completed
![Screenshot 2023-06-15 at 4 26 07 PM](https://github.com/datafold/data-diff/assets/11282254/dae06309-1dce-4ad6-8cb0-12b924e8e559)
