### PR TITLE
fix reversal of rows added and removed

### DIFF
--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -140,8 +140,8 @@ class DiffResultWrapper:
 
         if is_dbt:
             string_output = dbt_diff_string_template(
-                diff_stats.diff_by_sign["-"],
                 diff_stats.diff_by_sign["+"],
+                diff_stats.diff_by_sign["-"],
                 diff_stats.diff_by_sign["!"],
                 diff_stats.unchanged,
                 diff_stats.extra_column_diffs,


### PR DESCRIPTION
Addresses https://github.com/datafold/data-diff/issues/629, bug(?) that caused "Rows Added" and "Rows Removed" to be reversed in the `--dbt` CLI printout.