### PR TITLE
include only rows with equal PK to values diff stats in --json output

### DIFF
--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -165,8 +165,8 @@ class DiffResultWrapper:
 
         return string_output
 
-    def get_stats_dict(self):
-        diff_stats = self._get_stats()
+    def get_stats_dict(self, is_dbt: bool = False):
+        diff_stats = self._get_stats(is_dbt)
         json_output = {
             "rows_A": diff_stats.table1_count,
             "rows_B": diff_stats.table2_count,
@@ -177,6 +177,8 @@ class DiffResultWrapper:
             "total": sum(diff_stats.diff_by_sign.values()),
             "stats": self.stats,
         }
+        if diff_stats.extra_column_diffs:
+            json_output["values"] = diff_stats.extra_column_diffs
 
         return json_output
 

--- a/data_diff/format.py
+++ b/data_diff/format.py
@@ -51,7 +51,7 @@ def jsonify(
 
     summary = None
     if with_summary:
-        summary = _jsonify_diff_summary(diff.get_stats_dict())
+        summary = _jsonify_diff_summary(diff.get_stats_dict(is_dbt=True))
 
     columns = None
     if with_columns:
@@ -258,7 +258,7 @@ def _jsonify_diff_summary(stats_dict: dict) -> JsonDiffSummary:
             updated=stats_dict["updated"],
             unchanged=stats_dict["unchanged"],
         ),
-        stats=Stats(diffCounts=stats_dict["stats"]["diff_counts"]),
+        stats=Stats(diffCounts=stats_dict["values"]),
     )
 
 


### PR DESCRIPTION
We used to count differences across all rows for the "diffCounts" metric, even added/removed rows, for `--json` output format. Replaced that with `extra_column_diffs` value — the one we currently use for normal output.

**Normal output**
<img width="975" alt="image" src="https://github.com/datafold/data-diff/assets/18095933/ce90a2d1-3b6b-4c12-b180-8dfce67ed78b">

**--json**
```
{
  "status": "success", 
  "result": "different", 
  "model": "model.dbt_valentin_snowflake.downstream_different_from_row_diff", ..., 
  "stats": {"diffCounts": {"VALUE": 3}}},
  ...
}
```
