### PR TITLE
fix KeyError exception for --json diffs

### DIFF
--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -177,9 +177,7 @@ class DiffResultWrapper:
             "total": sum(diff_stats.diff_by_sign.values()),
             "stats": self.stats,
         }
-        if diff_stats.extra_column_diffs:
-            json_output["values"] = diff_stats.extra_column_diffs
-
+        json_output["values"] = diff_stats.extra_column_diffs  or {}
         return json_output
 
 

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -177,7 +177,7 @@ class DiffResultWrapper:
             "total": sum(diff_stats.diff_by_sign.values()),
             "stats": self.stats,
         }
-        json_output["values"] = diff_stats.extra_column_diffs  or {}
+        json_output["values"] = diff_stats.extra_column_diffs or {}
         return json_output
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -66,7 +66,7 @@ class TestApi(DiffTestCase):
             "updated": 0,
             "unchanged": 4,
             "total": 1,
-            # "stats": {"rows_downloaded": 5},
+            "values": {},
         }
         t1 = connect_to_table(TEST_MYSQL_CONN_STRING, self.table_src_name)
         t2 = connect_to_table(TEST_MYSQL_CONN_STRING, self.table_dst_name)


### PR DESCRIPTION
Fix `get_stats_dict` function so that `values` dict is always there to avoid possible KeyErrors.