### PR TITLE
poll more frequently when using --cloud

### DIFF
--- a/data_diff/errors.py
+++ b/data_diff/errors.py
@@ -60,3 +60,11 @@ class DataDiffNoDatasourceIdError(Exception):
 
 class DataDiffDatasourceIdNotFoundError(Exception):
     "Raised when using --cloud but the datasource_id is not found for a particular org."
+
+
+class DataDiffCloudDiffFailed(Exception):
+    "Raised when using --cloud and the remote diff fails."
+
+
+class DataDiffCloudDiffTimedOut(Exception):
+    "Raised when using --cloud and the diff did not return finish before the timeout value."


### PR DESCRIPTION
Poll more frequently when using `--dbt --cloud`

Biggest change is that the backoff is now additive, it just increases by 1 sec each iteration to a max of 20 sec vs. the former doubling.


Also created custom exceptions for existing generic exceptions since I was in there.