### PR TITLE
get prod alias from manifest file when provided

### DIFF
--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -684,9 +684,11 @@ class TestDbtDiffer(unittest.TestCase):
         mock_prod_manifest.nodes.get.return_value = mock_prod_model
         mock_prod_model.database = "prod_db"
         mock_prod_model.schema_ = "prod_schema"
-        prod_database, prod_schema = _get_prod_path_from_manifest(mock_model, mock_prod_manifest)
+        mock_prod_model.alias = "prod_alias"
+        prod_database, prod_schema, prod_alias = _get_prod_path_from_manifest(mock_model, mock_prod_manifest)
         self.assertEqual(prod_database, mock_prod_model.database)
         self.assertEqual(prod_schema, mock_prod_model.schema_)
+        self.assertEqual(prod_alias, mock_prod_model.alias)
 
     def test_get_prod_path_from_manifest_model_not_exists(self):
         mock_model = Mock()
@@ -696,9 +698,11 @@ class TestDbtDiffer(unittest.TestCase):
         mock_prod_manifest.nodes.get.return_value = None
         mock_prod_model.database = "prod_db"
         mock_prod_model.schema_ = "prod_schema"
-        prod_database, prod_schema = _get_prod_path_from_manifest(mock_model, mock_prod_manifest)
+        mock_prod_model.alias = "prod_alias"
+        prod_database, prod_schema, prod_alias = _get_prod_path_from_manifest(mock_model, mock_prod_manifest)
         self.assertEqual(prod_database, None)
         self.assertEqual(prod_schema, None)
+        self.assertEqual(prod_alias, None)
 
     def test_get_diff_custom_schema_no_config_exception(self):
         config = TDatadiffConfig(prod_database="prod_db", prod_schema="prod_schema")
@@ -926,7 +930,7 @@ class TestDbtDiffer(unittest.TestCase):
         mock_dbt_parser.requires_upper = False
         mock_model.meta = None
         mock_dbt_parser.prod_manifest_obj = {"manifest_key": "manifest_value"}
-        mock_prod_path_from_manifest.return_value = ("prod_db", "prod_schema")
+        mock_prod_path_from_manifest.return_value = ("prod_db", "prod_schema", "prod_alias")
 
         diff_vars = _get_diff_vars(mock_dbt_parser, config, mock_model)
 


### PR DESCRIPTION
Resolves https://github.com/datafold/data-diff/issues/646

Currently the model alias is extracted from the `run_results` file even when the `manifest` file is provided, which doesn't allow to use data-diff when the prod aliases are different. 
This PR modifies this behaviour and extracts the prod aliases from the `manifest` file when provided. 