### PR TITLE
Fix for more than 50 fields in Postgres

### DIFF
--- a/data_diff/sqeleton/databases/postgresql.py
+++ b/data_diff/sqeleton/databases/postgresql.py
@@ -1,3 +1,4 @@
+from typing import List
 from ..abcs.database_types import (
     DbPath,
     JSON,
@@ -91,6 +92,10 @@ class PostgresqlDialect(BaseDialect, Mixin_Schema):
 
     def to_string(self, s: str):
         return f"{s}::varchar"
+
+    def concat(self, items: List[str]) -> str:
+        joined_exprs = " || ".join(items)
+        return f"({joined_exprs})"
 
     def _convert_db_precision_to_digits(self, p: int) -> int:
         # Subtracting 2 due to wierd precision issues in PostgreSQL


### PR DESCRIPTION
Postgres does not allow functions that have more that have more than 100 arguments. When using the concat function, this limits comparisons to less than 50 fields.
Using `||` for concat like the Oracle variant fixes this.