### PR TITLE
tolerate Non-Alphanum Text() values for PKs

### DIFF
--- a/data_diff/sqeleton/abcs/database_types.py
+++ b/data_diff/sqeleton/abcs/database_types.py
@@ -83,7 +83,7 @@ class Decimal(FractionalType, IKey):  # Snowflake may use Decimal as a key
 
 
 @dataclass
-class StringType(ColType):
+class StringType(ColType, IKey):
     python_type = str
 
 

--- a/data_diff/sqeleton/databases/base.py
+++ b/data_diff/sqeleton/databases/base.py
@@ -491,11 +491,10 @@ class Database(AbstractDatabase[T]):
                 if alphanum_samples:
                     if len(alphanum_samples) != len(samples):
                         logger.debug(
-                            f"Mixed Alphanum/Non-Alphanum values detected in column {'.'.join(table_path)}.{col_name}. It cannot be used as a key."
+                            f"Mixed Alphanum/Non-Alphanum values detected in column {'.'.join(table_path)}.{col_name}."
                         )
-                    else:
-                        assert col_name in col_dict
-                        col_dict[col_name] = String_VaryingAlphanum()
+                    assert col_name in col_dict
+                    col_dict[col_name] = String_VaryingAlphanum()
 
     # @lru_cache()
     # def get_table_schema(self, path: DbPath) -> Dict[str, ColType]:

--- a/data_diff/sqeleton/databases/base.py
+++ b/data_diff/sqeleton/databases/base.py
@@ -491,10 +491,11 @@ class Database(AbstractDatabase[T]):
                 if alphanum_samples:
                     if len(alphanum_samples) != len(samples):
                         logger.debug(
-                            f"Mixed Alphanum/Non-Alphanum values detected in column {'.'.join(table_path)}.{col_name}."
+                            f"Mixed Alphanum/Non-Alphanum values detected in column {'.'.join(table_path)}.{col_name}. It cannot be used as a key."
                         )
-                    assert col_name in col_dict
-                    col_dict[col_name] = String_VaryingAlphanum()
+                    else:
+                        assert col_name in col_dict
+                        col_dict[col_name] = String_VaryingAlphanum()
 
     # @lru_cache()
     # def get_table_schema(self, path: DbPath) -> Dict[str, ColType]:


### PR DESCRIPTION
I'm not sure which alarms this will set off (test failures or otherwise), but I'd like to get started on supporting all `Text()` PKs.