### PR TITLE
clarify getting started for dbt vs xdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ More information about the algorithm and performance considerations can be found
 # Get started
 
 ## Validating dbt model changes between dev and prod
-💡 Looking to use `data-diff` in dbt development? Head over to [our `data-diff` + `dbt` documentation](https://www.datafold.com/data-deployment-testing) to get started!
+💡 Looking to use `data-diff` in dbt development? Head over to [our `data-diff` + `dbt` documentation](https://docs.datafold.com/development_testing/open_source/) to get started!
 
 ## Compare data tables between databases
 Install `data-diff` with specific database adapters, e.g.:

--- a/README.md
+++ b/README.md
@@ -67,10 +67,14 @@ When comparing the data, `data-diff` utilizes the resources of the underlying da
 - Time complexity approximates COUNT(*) operation when there are few differences
 - Performance degrades when datasets have a large number of differences
 
-More information about the algorithm and performance considerations can be found [here](https://github.com/datafold/data-diff/blob/master/docs/technical-explanation.md)
+More information about the algorithm and performance considerations can be found [here](https://github.com/datafold/data-diff/blob/master/docs/technical-explanation.md).
 
 # Get started
 
+## Validating dbt model changes between dev and prod
+💡 Looking to use `data-diff` in dbt development? Head over to [our `data-diff` + `dbt` documentation](https://www.datafold.com/data-deployment-testing) to get started!
+
+## Compare data tables between databases
 Install `data-diff` with specific database adapters, e.g.:
 
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ More information about the algorithm and performance considerations can be found
 💡 Looking to use `data-diff` in dbt development? Head over to [our `data-diff` + `dbt` documentation](https://docs.datafold.com/development_testing/open_source/) to get started!
 
 ## Compare data tables between databases
-Install `data-diff` with specific database adapters, e.g.:
+🔀 To compare data between databases, install `data-diff` with specific database adapters, e.g.:
 
 ```
 pip install data-diff 'data-diff[postgresql,snowflake]' -U

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ More information about the algorithm and performance considerations can be found
 # Get started
 
 ## Validating dbt model changes between dev and prod
-💡 Looking to use `data-diff` in dbt development? Head over to [our `data-diff` + `dbt` documentation](https://docs.datafold.com/development_testing/open_source/) to get started!
+⚡ Looking to use `data-diff` in dbt development? Head over to [our `data-diff` + `dbt` documentation](https://docs.datafold.com/development_testing/open_source/) to get started!
 
 ## Compare data tables between databases
 🔀 To compare data between databases, install `data-diff` with specific database adapters, e.g.:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ When comparing the data, `data-diff` utilizes the resources of the underlying da
 - Time complexity approximates COUNT(*) operation when there are few differences
 - Performance degrades when datasets have a large number of differences
 
-More information about the algorithm and performance considerations can be found [here](https://github.com/datafold/data-diff/blob/master/docs/technical-explanation.md).
+More information about the algorithm and performance considerations can be found [here](https://github.com/datafold/data-diff/blob/master/docs/technical-explanation.md)
 
 # Get started
 


### PR DESCRIPTION
dbt devs should be directed to https://docs.datafold.com/development_testing/open_source/ instead of being presented with the vanilla `data-diff` CLI instructions for getting started. 

With this PR, we'll have essentially separate "getting started" notes for the XDB vs dbt use cases, which don't overlap and have very different user personas.