### PR TITLE
Circular reference dbt 1.4.7

### DIFF
--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -269,7 +269,7 @@ class DbtParser:
         return project_dict
 
     def get_connection_creds(self) -> Tuple[Dict[str, str], str]:
-        # circular reference with dbt-artifacts-parser
+        # circular reference
         # noticed on dbt-core 1.4
         from dbt.config.renderer import ProfileRenderer
 

--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -8,7 +8,6 @@ import yaml
 from packaging.version import parse as parse_version
 import pydantic
 from dbt_artifacts_parser.parser import parse_run_results, parse_manifest
-from dbt.config.renderer import ProfileRenderer
 
 from data_diff.errors import (
     DataDiffDbtBigQueryUnsupportedMethodError,
@@ -270,6 +269,10 @@ class DbtParser:
         return project_dict
 
     def get_connection_creds(self) -> Tuple[Dict[str, str], str]:
+        # circular reference with dbt-artifacts-parser
+        # noticed on dbt-core 1.4
+        from dbt.config.renderer import ProfileRenderer
+
         profiles_path = self.profiles_dir / PROFILES_FILE
         with open(profiles_path) as profiles:
             logger.info(f"Parsing file {profiles_path}")

--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -270,7 +270,7 @@ class DbtParser:
 
     def get_connection_creds(self) -> Tuple[Dict[str, str], str]:
         # circular reference
-        # noticed on dbt-core 1.4
+        # noticed on dbt-core 1.4.7
         from dbt.config.renderer import ProfileRenderer
 
         profiles_path = self.profiles_dir / PROFILES_FILE


### PR DESCRIPTION
Happened to notice that dbt 1.4.7 causes a circular reference exception when using data-diff



```
  File "/Users/dan/repos/dbt-analytics/.venv3/lib/python3.9/site-packages/dbt/exceptions.py", line 7, in <module>
    from dbt.internal_deprecations import deprecated
  File "/Users/dan/repos/dbt-analytics/.venv3/lib/python3.9/site-packages/dbt/internal_deprecations.py", line 4, in <module>
    from dbt.events.functions import warn_or_error
ImportError: cannot import name 'warn_or_error' from partially initialized module 'dbt.events.functions' (most likely due to a circular import)
```

Highlights the need to test additional dbt versions in CI