### PR TITLE
add option `--init-oracle-client-lib-dir`

### DIFF
--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -250,6 +250,12 @@ click.Context.formatter_class = MyHelpFormatter
     help="Which directory to look in for the dbt_project.yml file. Default is the current working directory and its parents.",
 )
 @click.option(
+    "--init-oracle-client-lib-dir",
+    default=None,
+    metavar="PATH",
+    help="Path to the Oracle client library. Only relevant for Oracle databases.",
+)
+@click.option(
     "--select",
     "-s",
     default=None,
@@ -363,6 +369,7 @@ def _data_diff(
     cloud,
     dbt_profiles_dir,
     dbt_project_dir,
+    init_oracle_client_lib_dir,
     select,
     state,
     threads1=None,
@@ -401,6 +408,11 @@ def _data_diff(
             f"Error: Databases not specified. Got {database1} and {database2}. Use --help for more information."
         )
         return
+
+    if init_oracle_client_lib_dir:
+        logging.debug(f"Initializing Oracle client library from {init_oracle_client_lib_dir}")
+        import oracledb
+        oracledb.init_oracle_client(lib_dir=init_oracle_client_lib_dir)
 
     db1 = connect(database1, threads1 or threads)
     if database1 == database2:

--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -412,7 +412,12 @@ def _data_diff(
     if init_oracle_client_lib_dir:
         logging.debug(f"Initializing Oracle client library from {init_oracle_client_lib_dir}")
         import oracledb
-        oracledb.init_oracle_client(lib_dir=init_oracle_client_lib_dir)
+        # On Linux and related platforms, enable Thick mode by calling init_oracle_client() without passing a lib_dir parameter.
+        # See https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#enabling-python-oracledb-thick-mode-on-linux-and-related-platforms
+        if sys.platform.startswith("linux"):
+            oracledb.init_oracle_client()
+        else:
+            oracledb.init_oracle_client(lib_dir=init_oracle_client_lib_dir)
 
     db1 = connect(database1, threads1 or threads)
     if database1 == database2:


### PR DESCRIPTION
4b2ca27479d28e7409d0b01404154319072c165f switchs oracle driver from `cx_Oracle` to `oracledb`, causing older oracle databases (11g particularly) [not supported](https://python-oracledb.readthedocs.io/en/latest/user_guide/installation.html#supported-oracle-database-versions)

this PR add `--init-oracle-client-lib-dir` option to enable oracledb’s [thick mode](https://python-oracledb.readthedocs.io/en/latest/user_guide/installation.html#supported-oracle-database-versions), and therefore support oralce 11g