### PR TITLE
Initialise mutable fields of dataclasses safely for reuse

### DIFF
--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -4,6 +4,7 @@
 import re
 import time
 from abc import ABC, abstractmethod
+from dataclasses import field
 from enum import Enum
 from contextlib import contextmanager
 from operator import methodcaller
@@ -88,7 +89,7 @@ class DiffResultWrapper:
     diff: iter  # DiffResult
     info_tree: InfoTree
     stats: dict
-    result_list: list = []
+    result_list: list = field(default_factory=list)
 
     def __iter__(self):
         yield from self.result_list

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -1,4 +1,5 @@
 import os
+from dataclasses import field
 from numbers import Number
 import logging
 from collections import defaultdict
@@ -75,7 +76,7 @@ class HashDiffer(TableDiffer):
     bisection_factor: int = DEFAULT_BISECTION_FACTOR
     bisection_threshold: Number = DEFAULT_BISECTION_THRESHOLD  # Accepts inf for tests
 
-    stats: dict = {}
+    stats: dict = field(default_factory=dict)
 
     def __post_init__(self):
         # Validate options

--- a/data_diff/info_tree.py
+++ b/data_diff/info_tree.py
@@ -1,3 +1,4 @@
+from dataclasses import field
 from typing import List, Dict, Optional, Any, Tuple, Union
 
 from runtype import dataclass
@@ -14,7 +15,7 @@ class SegmentInfo:
     is_diff: bool = None
     diff_count: int = None
 
-    rowcounts: Dict[int, int] = {}
+    rowcounts: Dict[int, int] = field(default_factory=dict)
     max_rows: int = None
 
     def set_diff(self, diff: List[Union[Tuple[Any, ...], List[Any]]], schema: Optional[Tuple[Tuple[str, type]]] = None):
@@ -42,7 +43,7 @@ class SegmentInfo:
 @dataclass
 class InfoTree:
     info: SegmentInfo
-    children: List["InfoTree"] = []
+    children: List["InfoTree"] = field(default_factory=list)
 
     def add_node(self, table1: TableSegment, table2: TableSegment, max_rows: int = None):
         node = InfoTree(SegmentInfo([table1, table2], max_rows=max_rows))

--- a/data_diff/joindiff_tables.py
+++ b/data_diff/joindiff_tables.py
@@ -1,7 +1,7 @@
 """Provides classes for performing a table diff using JOIN
 
 """
-
+from dataclasses import field
 from decimal import Decimal
 from functools import partial
 import logging
@@ -141,7 +141,7 @@ class JoinDiffer(TableDiffer):
     table_write_limit: int = TABLE_WRITE_LIMIT
     skip_null_keys: bool = False
 
-    stats: dict = {}
+    stats: dict = field(default_factory=dict)
 
     def _diff_tables_root(self, table1: TableSegment, table2: TableSegment, info_tree: InfoTree) -> DiffResult:
         db = table1.database

--- a/data_diff/sqeleton/queries/compiler.py
+++ b/data_diff/sqeleton/queries/compiler.py
@@ -1,4 +1,5 @@
 import random
+from dataclasses import field
 from datetime import datetime
 from typing import Any, Dict, Sequence, List
 
@@ -23,15 +24,15 @@ class Root:
 @dataclass
 class Compiler(AbstractCompiler):
     database: AbstractDatabase
-    params: dict = {}
+    params: dict = field(default_factory=dict)
     in_select: bool = False  # Compilation runtime flag
     in_join: bool = False  # Compilation runtime flag
 
-    _table_context: List = []  # List[ITable]
-    _subqueries: Dict[str, Any] = {}  # XXX not thread-safe
+    _table_context: List = field(default_factory=list)  # List[ITable]
+    _subqueries: Dict[str, Any] = field(default_factory=dict)  # XXX not thread-safe
     root: bool = True
 
-    _counter: List = [0]
+    _counter: List = field(default_factory=lambda: [0])
 
     @property
     def dialect(self) -> AbstractDialect:


### PR DESCRIPTION
Otherwise, if the differs are reused multiple times within the same process, there is a risk of leaking accumulated data from the previous runs into the following runs.

In some cases, it can be "solved" by re-initializing these fields explicitly before data accumulation (e.g. `self.fld = {...}`), or by overwriting the same dict keys on every run — but neither of these is reliable. The field's content must be strictly coupled to the containing object and its lifetime and also disposed of when the object is disposed of.