### PR TITLE
Simplify by replacing the self-made WeakCache with the builtin WeakValueDict

### DIFF
--- a/data_diff/sqeleton/utils.py
+++ b/data_diff/sqeleton/utils.py
@@ -7,12 +7,10 @@ from typing import (
     Any,
     Sequence,
     Dict,
-    Hashable,
     TypeVar,
     List,
 )
 from abc import abstractmethod
-from weakref import ref
 import math
 import string
 import re
@@ -22,30 +20,6 @@ from urllib.parse import urlparse
 from typing_extensions import Self
 
 # -- Common --
-
-
-class WeakCache:
-    def __init__(self):
-        self._cache = {}
-
-    def _hashable_key(self, k: Union[dict, Hashable]) -> Hashable:
-        if isinstance(k, dict):
-            return tuple(k.items())
-        return k
-
-    def add(self, key: Union[dict, Hashable], value: Any):
-        key = self._hashable_key(key)
-        self._cache[key] = ref(value)
-
-    def get(self, key: Union[dict, Hashable]) -> Any:
-        key = self._hashable_key(key)
-
-        value = self._cache[key]()
-        if value is None:
-            del self._cache[key]
-            raise KeyError(f"Key {key} not found, or no longer a valid reference")
-
-        return value
 
 
 def join_iter(joiner: Any, iterable: Iterable) -> Iterable:

--- a/tests/sqeleton/test_utils.py
+++ b/tests/sqeleton/test_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from data_diff.sqeleton.utils import remove_passwords_in_dict, match_regexps, match_like, number_to_human, WeakCache
+from data_diff.sqeleton.utils import remove_passwords_in_dict, match_regexps, match_like, number_to_human
 
 
 class TestUtils(unittest.TestCase):
@@ -81,24 +81,3 @@ class TestUtils(unittest.TestCase):
         assert number_to_human(-1000) == "-1k"
         assert number_to_human(-1000000) == "-1m"
         assert number_to_human(-1000000000) == "-1b"
-
-    def test_weak_cache(self):
-        # Create cache
-        cache = WeakCache()
-
-        # Test adding and retrieving basic value
-        o = {1, 2}
-        cache.add("key", o)
-        assert cache.get("key") is o
-
-        # Test adding and retrieving dict value
-        cache.add({"key": "value"}, o)
-        assert cache.get({"key": "value"}) is o
-
-        # Test deleting value when reference is lost
-        del o
-        try:
-            cache.get({"key": "value"})
-            assert False, "KeyError should have been raised"
-        except KeyError:
-            pass


### PR DESCRIPTION
As a part of the series of simplifications, basically as a preliminary warmup/cleanup: remove unnecessary entities & abstractions.