### PR TITLE
Normalise all imports to fully qualified names

### DIFF
--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -2,13 +2,13 @@ from typing import Sequence, Tuple, Iterator, Optional, Union
 
 from data_diff.sqeleton.abcs import DbTime, DbPath
 
-from .tracking import disable_tracking
-from .databases import connect
-from .diff_tables import Algorithm
-from .hashdiff_tables import HashDiffer, DEFAULT_BISECTION_THRESHOLD, DEFAULT_BISECTION_FACTOR
-from .joindiff_tables import JoinDiffer, TABLE_WRITE_LIMIT
-from .table_segment import TableSegment
-from .utils import eval_name_template, Vector
+from data_diff.tracking import disable_tracking
+from data_diff.databases import connect
+from data_diff.diff_tables import Algorithm
+from data_diff.hashdiff_tables import HashDiffer, DEFAULT_BISECTION_THRESHOLD, DEFAULT_BISECTION_FACTOR
+from data_diff.joindiff_tables import JoinDiffer, TABLE_WRITE_LIMIT
+from data_diff.table_segment import TableSegment
+from data_diff.utils import eval_name_template, Vector
 
 
 def connect_to_table(

--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -15,17 +15,17 @@ import click
 from data_diff.sqeleton.schema import create_schema
 from data_diff.sqeleton.queries.api import current_timestamp
 
-from .dbt import dbt_diff
-from .utils import eval_name_template, remove_password_from_url, safezip, match_like, LogStatusHandler
-from .diff_tables import Algorithm
-from .hashdiff_tables import HashDiffer, DEFAULT_BISECTION_THRESHOLD, DEFAULT_BISECTION_FACTOR
-from .joindiff_tables import TABLE_WRITE_LIMIT, JoinDiffer
-from .table_segment import TableSegment
-from .databases import connect
-from .parse_time import parse_time_before, UNITS_STR, ParseError
-from .config import apply_config_from_file
-from .tracking import disable_tracking, set_entrypoint_name
-from .version import __version__
+from data_diff.dbt import dbt_diff
+from data_diff.utils import eval_name_template, remove_password_from_url, safezip, match_like, LogStatusHandler
+from data_diff.diff_tables import Algorithm
+from data_diff.hashdiff_tables import HashDiffer, DEFAULT_BISECTION_THRESHOLD, DEFAULT_BISECTION_FACTOR
+from data_diff.joindiff_tables import TABLE_WRITE_LIMIT, JoinDiffer
+from data_diff.table_segment import TableSegment
+from data_diff.databases import connect
+from data_diff.parse_time import parse_time_before, UNITS_STR, ParseError
+from data_diff.config import apply_config_from_file
+from data_diff.tracking import disable_tracking, set_entrypoint_name
+from data_diff.version import __version__
 
 
 COLOR_SCHEME = {

--- a/data_diff/cloud/__init__.py
+++ b/data_diff/cloud/__init__.py
@@ -1,2 +1,2 @@
-from .datafold_api import DatafoldAPI, TCloudApiDataDiff, TCloudApiOrgMeta
-from .data_source import get_or_create_data_source
+from data_diff.cloud.datafold_api import DatafoldAPI, TCloudApiDataDiff, TCloudApiOrgMeta
+from data_diff.cloud.data_source import get_or_create_data_source

--- a/data_diff/cloud/data_source.py
+++ b/data_diff/cloud/data_source.py
@@ -8,14 +8,14 @@ from rich.table import Table
 from rich.prompt import Confirm, Prompt, FloatPrompt, IntPrompt, InvalidResponse
 from typing_extensions import Literal
 
-from .datafold_api import (
+from data_diff.cloud.datafold_api import (
     DatafoldAPI,
     TCloudApiDataSourceConfigSchema,
     TCloudApiDataSource,
     TDsConfig,
     TestDataSourceStatus,
 )
-from ..dbt_parser import DbtParser
+from data_diff.cloud.dbt_parser import DbtParser
 
 
 UNKNOWN_VALUE = "unknown_value"

--- a/data_diff/cloud/datafold_api.py
+++ b/data_diff/cloud/datafold_api.py
@@ -10,7 +10,7 @@ from typing_extensions import Self
 
 from data_diff.errors import DataDiffCloudDiffFailed, DataDiffCloudDiffTimedOut, DataDiffDatasourceIdNotFoundError
 
-from ..utils import getLogger
+from data_diff.cloud.utils import getLogger
 
 logger = getLogger(__name__)
 

--- a/data_diff/databases/__init__.py
+++ b/data_diff/databases/__init__.py
@@ -1,17 +1,17 @@
 from data_diff.sqeleton.databases import MD5_HEXDIGITS, CHECKSUM_HEXDIGITS, QueryError, ConnectError
 
-from .postgresql import PostgreSQL
-from .mysql import MySQL
-from .oracle import Oracle
-from .snowflake import Snowflake
-from .bigquery import BigQuery
-from .redshift import Redshift
-from .presto import Presto
-from .databricks import Databricks
-from .trino import Trino
-from .clickhouse import Clickhouse
-from .vertica import Vertica
-from .duckdb import DuckDB
-from .mssql import MsSql
+from data_diff.databases.postgresql import PostgreSQL
+from data_diff.databases.mysql import MySQL
+from data_diff.databases.oracle import Oracle
+from data_diff.databases.snowflake import Snowflake
+from data_diff.databases.bigquery import BigQuery
+from data_diff.databases.redshift import Redshift
+from data_diff.databases.presto import Presto
+from data_diff.databases.databricks import Databricks
+from data_diff.databases.trino import Trino
+from data_diff.databases.clickhouse import Clickhouse
+from data_diff.databases.vertica import Vertica
+from data_diff.databases.duckdb import DuckDB
+from data_diff.databases.mssql import MsSql
 
-from ._connect import connect
+from data_diff.databases._connect import connect

--- a/data_diff/databases/_connect.py
+++ b/data_diff/databases/_connect.py
@@ -2,19 +2,19 @@ import logging
 
 from data_diff.sqeleton.databases import Connect
 
-from .postgresql import PostgreSQL
-from .mysql import MySQL
-from .oracle import Oracle
-from .snowflake import Snowflake
-from .bigquery import BigQuery
-from .redshift import Redshift
-from .presto import Presto
-from .databricks import Databricks
-from .trino import Trino
-from .clickhouse import Clickhouse
-from .vertica import Vertica
-from .duckdb import DuckDB
-from .mssql import MsSql
+from data_diff.databases.postgresql import PostgreSQL
+from data_diff.databases.mysql import MySQL
+from data_diff.databases.oracle import Oracle
+from data_diff.databases.snowflake import Snowflake
+from data_diff.databases.bigquery import BigQuery
+from data_diff.databases.redshift import Redshift
+from data_diff.databases.presto import Presto
+from data_diff.databases.databricks import Databricks
+from data_diff.databases.trino import Trino
+from data_diff.databases.clickhouse import Clickhouse
+from data_diff.databases.vertica import Vertica
+from data_diff.databases.duckdb import DuckDB
+from data_diff.databases.mssql import MsSql
 
 
 DATABASE_BY_SCHEME = {

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import bigquery
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(bigquery.Dialect, bigquery.Mixin_MD5, bigquery.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/clickhouse.py
+++ b/data_diff/databases/clickhouse.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import clickhouse
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(clickhouse.Dialect, clickhouse.Mixin_MD5, clickhouse.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/databricks.py
+++ b/data_diff/databases/databricks.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import databricks
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(databricks.Dialect, databricks.Mixin_MD5, databricks.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/duckdb.py
+++ b/data_diff/databases/duckdb.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import duckdb
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(duckdb.Dialect, duckdb.Mixin_MD5, duckdb.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import mssql
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(mssql.Dialect, mssql.Mixin_MD5, mssql.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/mysql.py
+++ b/data_diff/databases/mysql.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import mysql
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(mysql.Dialect, mysql.Mixin_MD5, mysql.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/oracle.py
+++ b/data_diff/databases/oracle.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import oracle
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(oracle.Dialect, oracle.Mixin_MD5, oracle.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import postgresql as pg
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class PostgresqlDialect(pg.PostgresqlDialect, pg.Mixin_MD5, pg.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/presto.py
+++ b/data_diff/databases/presto.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import presto
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(presto.Dialect, presto.Mixin_MD5, presto.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/redshift.py
+++ b/data_diff/databases/redshift.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import redshift
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(redshift.Dialect, redshift.Mixin_MD5, redshift.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/snowflake.py
+++ b/data_diff/databases/snowflake.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import snowflake
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(snowflake.Dialect, snowflake.Mixin_MD5, snowflake.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/trino.py
+++ b/data_diff/databases/trino.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import trino
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(trino.Dialect, trino.Mixin_MD5, trino.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/databases/vertica.py
+++ b/data_diff/databases/vertica.py
@@ -1,5 +1,5 @@
 from data_diff.sqeleton.databases import vertica
-from .base import DatadiffDialect
+from data_diff.databases.base import DatadiffDialect
 
 
 class Dialect(vertica.Dialect, vertica.Mixin_MD5, vertica.Mixin_NormalizeValue, DatadiffDialect):

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -16,12 +16,12 @@ from data_diff.errors import (
     DataDiffNoDatasourceIdError,
 )
 
-from . import connect_to_table, diff_tables, Algorithm
-from .cloud import DatafoldAPI, TCloudApiDataDiff, TCloudApiOrgMeta
-from .dbt_parser import DbtParser, TDatadiffConfig
-from .diff_tables import DiffResultWrapper
-from .format import jsonify, jsonify_error
-from .tracking import (
+from data_diff import connect_to_table, diff_tables, Algorithm
+from data_diff.cloud import DatafoldAPI, TCloudApiDataDiff, TCloudApiOrgMeta
+from data_diff.dbt_parser import DbtParser, TDatadiffConfig
+from data_diff.diff_tables import DiffResultWrapper
+from data_diff.format import jsonify, jsonify_error
+from data_diff.tracking import (
     bool_ask_for_email,
     bool_notify_about_extension,
     create_email_signup_event_json,
@@ -34,7 +34,7 @@ from .tracking import (
     send_event_json,
     is_tracking_enabled,
 )
-from .utils import (
+from data_diff.utils import (
     dbt_diff_string_template,
     getLogger,
     columns_added_template,

--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from packaging.version import parse as parse_version
 from dbt.config.renderer import ProfileRenderer
-from .dbt_config_validators import ManifestJsonConfig, RunResultsJsonConfig
+from data_diff.dbt_config_validators import ManifestJsonConfig, RunResultsJsonConfig
 
 from data_diff.errors import (
     DataDiffDbtBigQueryUnsupportedMethodError,
@@ -24,7 +24,7 @@ from data_diff.errors import (
     DataDiffSimpleSelectNotFound,
 )
 
-from .utils import getLogger, get_from_dict_with_raise
+from data_diff.utils import getLogger, get_from_dict_with_raise
 
 
 logger = getLogger(__name__)

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -15,10 +15,10 @@ from runtype import dataclass
 
 from data_diff.info_tree import InfoTree, SegmentInfo
 
-from .utils import dbt_diff_string_template, run_as_daemon, safezip, getLogger, truncate_error, Vector
-from .thread_utils import ThreadedYielder
-from .table_segment import TableSegment, create_mesh_from_points
-from .tracking import create_end_event_json, create_start_event_json, send_event_json, is_tracking_enabled
+from data_diff.utils import dbt_diff_string_template, run_as_daemon, safezip, getLogger, truncate_error, Vector
+from data_diff.thread_utils import ThreadedYielder
+from data_diff.table_segment import TableSegment, create_mesh_from_points
+from data_diff.tracking import create_end_event_json, create_start_event_json, send_event_json, is_tracking_enabled
 from data_diff.sqeleton.abcs import IKey
 
 logger = getLogger(__name__)

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -10,12 +10,12 @@ from runtype import dataclass
 
 from data_diff.sqeleton.abcs import ColType_UUID, NumericType, PrecisionType, StringType, Boolean, JSON
 
-from .info_tree import InfoTree
-from .utils import safezip, diffs_are_equiv_jsons
-from .thread_utils import ThreadedYielder
-from .table_segment import TableSegment
+from data_diff.info_tree import InfoTree
+from data_diff.utils import safezip, diffs_are_equiv_jsons
+from data_diff.thread_utils import ThreadedYielder
+from data_diff.table_segment import TableSegment
 
-from .diff_tables import TableDiffer
+from data_diff.diff_tables import TableDiffer
 
 BENCHMARK = os.environ.get("BENCHMARK", False)
 

--- a/data_diff/info_tree.py
+++ b/data_diff/info_tree.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Optional, Any, Tuple, Union
 
 from runtype import dataclass
 
-from .table_segment import TableSegment
+from data_diff.table_segment import TableSegment
 
 
 @dataclass(frozen=False)

--- a/data_diff/joindiff_tables.py
+++ b/data_diff/joindiff_tables.py
@@ -31,13 +31,13 @@ from data_diff.sqeleton.queries import (
 from data_diff.sqeleton.queries.ast_classes import Concat, Count, Expr, Func, Random, TablePath, Code, ITable
 from data_diff.sqeleton.queries.extras import NormalizeAsString
 
-from .info_tree import InfoTree
+from data_diff.info_tree import InfoTree
 
-from .query_utils import append_to_table, drop_table
-from .utils import safezip
-from .table_segment import TableSegment
-from .diff_tables import TableDiffer, DiffResult
-from .thread_utils import ThreadedYielder
+from data_diff.query_utils import append_to_table, drop_table
+from data_diff.utils import safezip
+from data_diff.table_segment import TableSegment
+from data_diff.diff_tables import TableDiffer, DiffResult
+from data_diff.thread_utils import ThreadedYielder
 
 
 logger = logging.getLogger("joindiff_tables")

--- a/data_diff/lexicographic_space.py
+++ b/data_diff/lexicographic_space.py
@@ -20,7 +20,7 @@ keys are not evenly distributed.
 from random import randint, randrange
 
 from typing import Tuple
-from .utils import safezip
+from data_diff.utils import safezip
 
 Vector = Tuple[int]
 Interval = Tuple[int]

--- a/data_diff/sqeleton/__init__.py
+++ b/data_diff/sqeleton/__init__.py
@@ -1,2 +1,2 @@
-from .databases import connect
-from .queries import table, this, SKIP, code
+from data_diff.sqeleton.databases import connect
+from data_diff.sqeleton.queries import table, this, SKIP, code

--- a/data_diff/sqeleton/__main__.py
+++ b/data_diff/sqeleton/__main__.py
@@ -1,5 +1,5 @@
 import click
-from .repl import repl as repl_main
+from data_diff.sqeleton.repl import repl as repl_main
 
 
 @click.group(no_args_is_help=True)

--- a/data_diff/sqeleton/abcs/__init__.py
+++ b/data_diff/sqeleton/abcs/__init__.py
@@ -1,4 +1,4 @@
-from .database_types import (
+from data_diff.sqeleton.abcs.database_types import (
     AbstractDatabase,
     AbstractDialect,
     DbKey,
@@ -12,4 +12,4 @@ from .database_types import (
     Boolean,
     JSON,
 )
-from .compiler import AbstractCompiler, Compilable
+from data_diff.sqeleton.abcs.compiler import AbstractCompiler, Compilable

--- a/data_diff/sqeleton/abcs/database_types.py
+++ b/data_diff/sqeleton/abcs/database_types.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from runtype import dataclass
 from typing_extensions import Self
 
-from ..utils import ArithAlphanumeric, ArithUUID, Unknown
+from data_diff.sqeleton.utils import ArithAlphanumeric, ArithUUID, Unknown
 
 
 DbPath = Tuple[str, ...]

--- a/data_diff/sqeleton/abcs/mixins.py
+++ b/data_diff/sqeleton/abcs/mixins.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from .database_types import (
+from data_diff.sqeleton.abcs.database_types import (
     Array,
     TemporalType,
     FractionalType,
@@ -10,7 +10,7 @@ from .database_types import (
     JSON,
     Struct,
 )
-from .compiler import Compilable
+from data_diff.sqeleton.abcs.compiler import Compilable
 
 
 class AbstractMixin(ABC):

--- a/data_diff/sqeleton/bound_exprs.py
+++ b/data_diff/sqeleton/bound_exprs.py
@@ -7,10 +7,10 @@ from typing import Union, TYPE_CHECKING
 from runtype import dataclass
 from typing_extensions import Self
 
-from .abcs import AbstractDatabase, AbstractCompiler
-from .queries.ast_classes import ExprNode, ITable, TablePath, Compilable
-from .queries.api import table
-from .schema import create_schema
+from data_diff.sqeleton.abcs import AbstractDatabase, AbstractCompiler
+from data_diff.sqeleton.queries.ast_classes import ExprNode, ITable, TablePath, Compilable
+from data_diff.sqeleton.queries.api import table
+from data_diff.sqeleton.schema import create_schema
 
 
 @dataclass
@@ -80,8 +80,8 @@ def bound_table(database: AbstractDatabase, table_path: Union[TablePath, str, tu
 # Database.table = bound_table
 
 # def test():
-#     from . import connect
-#     from .queries.api import table
+#     from data_diff.sqeleton. import connect
+#     from data_diff.sqeleton.queries.api import table
 #     d = connect("mysql://erez:qweqwe123@localhost/erez")
 #     t = table(('Rating',))
 

--- a/data_diff/sqeleton/databases/__init__.py
+++ b/data_diff/sqeleton/databases/__init__.py
@@ -1,19 +1,26 @@
-from .base import MD5_HEXDIGITS, CHECKSUM_HEXDIGITS, QueryError, ConnectError, BaseDialect, Database
-from ..abcs import DbPath, DbKey, DbTime
-from ._connect import Connect
+from data_diff.sqeleton.databases.base import (
+    MD5_HEXDIGITS,
+    CHECKSUM_HEXDIGITS,
+    QueryError,
+    ConnectError,
+    BaseDialect,
+    Database,
+)
+from data_diff.sqeleton.abcs import DbPath, DbKey, DbTime
+from data_diff.sqeleton.databases._connect import Connect
 
-from .postgresql import PostgreSQL
-from .mysql import MySQL
-from .oracle import Oracle
-from .snowflake import Snowflake
-from .bigquery import BigQuery
-from .redshift import Redshift
-from .presto import Presto
-from .databricks import Databricks
-from .trino import Trino
-from .clickhouse import Clickhouse
-from .vertica import Vertica
-from .duckdb import DuckDB
-from .mssql import MsSQL
+from data_diff.sqeleton.databases.postgresql import PostgreSQL
+from data_diff.sqeleton.databases.mysql import MySQL
+from data_diff.sqeleton.databases.oracle import Oracle
+from data_diff.sqeleton.databases.snowflake import Snowflake
+from data_diff.sqeleton.databases.bigquery import BigQuery
+from data_diff.sqeleton.databases.redshift import Redshift
+from data_diff.sqeleton.databases.presto import Presto
+from data_diff.sqeleton.databases.databricks import Databricks
+from data_diff.sqeleton.databases.trino import Trino
+from data_diff.sqeleton.databases.clickhouse import Clickhouse
+from data_diff.sqeleton.databases.vertica import Vertica
+from data_diff.sqeleton.databases.duckdb import DuckDB
+from data_diff.sqeleton.databases.mssql import MsSQL
 
 connect = Connect()

--- a/data_diff/sqeleton/databases/_connect.py
+++ b/data_diff/sqeleton/databases/_connect.py
@@ -8,21 +8,21 @@ import toml
 from runtype import dataclass
 from typing_extensions import Self
 
-from ..abcs.mixins import AbstractMixin
-from .base import Database, ThreadedDatabase
-from .postgresql import PostgreSQL
-from .mysql import MySQL
-from .oracle import Oracle
-from .snowflake import Snowflake
-from .bigquery import BigQuery
-from .redshift import Redshift
-from .presto import Presto
-from .databricks import Databricks
-from .trino import Trino
-from .clickhouse import Clickhouse
-from .vertica import Vertica
-from .duckdb import DuckDB
-from .mssql import MsSQL
+from data_diff.sqeleton.abcs.mixins import AbstractMixin
+from data_diff.sqeleton.databases.base import Database, ThreadedDatabase
+from data_diff.sqeleton.databases.postgresql import PostgreSQL
+from data_diff.sqeleton.databases.mysql import MySQL
+from data_diff.sqeleton.databases.oracle import Oracle
+from data_diff.sqeleton.databases.snowflake import Snowflake
+from data_diff.sqeleton.databases.bigquery import BigQuery
+from data_diff.sqeleton.databases.redshift import Redshift
+from data_diff.sqeleton.databases.presto import Presto
+from data_diff.sqeleton.databases.databricks import Databricks
+from data_diff.sqeleton.databases.trino import Trino
+from data_diff.sqeleton.databases.clickhouse import Clickhouse
+from data_diff.sqeleton.databases.vertica import Vertica
+from data_diff.sqeleton.databases.duckdb import DuckDB
+from data_diff.sqeleton.databases.mssql import MsSQL
 
 
 @dataclass

--- a/data_diff/sqeleton/databases/base.py
+++ b/data_diff/sqeleton/databases/base.py
@@ -13,10 +13,10 @@ import decimal
 from runtype import dataclass
 from typing_extensions import Self
 
-from ..utils import is_uuid, safezip
-from ..queries import Expr, Compiler, table, Select, SKIP, Explain, Code, this
-from ..queries.ast_classes import Random
-from ..abcs.database_types import (
+from data_diff.sqeleton.utils import is_uuid, safezip
+from data_diff.sqeleton.queries import Expr, Compiler, table, Select, SKIP, Explain, Code, this
+from data_diff.sqeleton.queries.ast_classes import Random
+from data_diff.sqeleton.abcs.database_types import (
     AbstractDatabase,
     Array,
     Struct,
@@ -39,14 +39,14 @@ from ..abcs.database_types import (
     Boolean,
     JSON,
 )
-from ..abcs.mixins import Compilable
-from ..abcs.mixins import (
+from data_diff.sqeleton.abcs.mixins import Compilable
+from data_diff.sqeleton.abcs.mixins import (
     AbstractMixin_Schema,
     AbstractMixin_RandomSample,
     AbstractMixin_NormalizeValue,
     AbstractMixin_OptimizerHints,
 )
-from ..bound_exprs import bound_table
+from data_diff.sqeleton.bound_exprs import bound_table
 
 logger = logging.getLogger("database")
 

--- a/data_diff/sqeleton/databases/bigquery.py
+++ b/data_diff/sqeleton/databases/bigquery.py
@@ -1,6 +1,6 @@
 import re
 from typing import Any, List, Union
-from ..abcs.database_types import (
+from data_diff.sqeleton.abcs.database_types import (
     ColType,
     Array,
     JSON,
@@ -17,16 +17,24 @@ from ..abcs.database_types import (
     Boolean,
     UnknownColType,
 )
-from ..abcs.mixins import (
+from data_diff.sqeleton.abcs.mixins import (
     AbstractMixin_MD5,
     AbstractMixin_NormalizeValue,
     AbstractMixin_Schema,
     AbstractMixin_TimeTravel,
 )
-from ..abcs import Compilable
-from ..queries import this, table, SKIP, code
-from .base import BaseDialect, Database, import_helper, parse_table_name, ConnectError, apply_query, QueryResult
-from .base import TIMESTAMP_PRECISION_POS, ThreadLocalInterpreter, Mixin_RandomSample
+from data_diff.sqeleton.abcs import Compilable
+from data_diff.sqeleton.queries import this, table, SKIP, code
+from data_diff.sqeleton.databases.base import (
+    BaseDialect,
+    Database,
+    import_helper,
+    parse_table_name,
+    ConnectError,
+    apply_query,
+    QueryResult,
+)
+from data_diff.sqeleton.databases.base import TIMESTAMP_PRECISION_POS, ThreadLocalInterpreter, Mixin_RandomSample
 
 
 @import_helper(text="Please install BigQuery and configure your google-cloud access.")

--- a/data_diff/sqeleton/databases/clickhouse.py
+++ b/data_diff/sqeleton/databases/clickhouse.py
@@ -1,6 +1,6 @@
 from typing import Optional, Type
 
-from .base import (
+from data_diff.sqeleton.databases.base import (
     MD5_HEXDIGITS,
     CHECKSUM_HEXDIGITS,
     TIMESTAMP_PRECISION_POS,
@@ -10,7 +10,7 @@ from .base import (
     ConnectError,
     Mixin_RandomSample,
 )
-from ..abcs.database_types import (
+from data_diff.sqeleton.abcs.database_types import (
     ColType,
     Decimal,
     Float,
@@ -22,7 +22,7 @@ from ..abcs.database_types import (
     Timestamp,
     Boolean,
 )
-from ..abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
+from data_diff.sqeleton.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
 
 # https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings/#default-database
 DEFAULT_DATABASE = "default"

--- a/data_diff/sqeleton/databases/databricks.py
+++ b/data_diff/sqeleton/databases/databricks.py
@@ -2,7 +2,7 @@ import math
 from typing import Dict, Sequence
 import logging
 
-from ..abcs.database_types import (
+from data_diff.sqeleton.abcs.database_types import (
     Integer,
     Float,
     Decimal,
@@ -15,8 +15,8 @@ from ..abcs.database_types import (
     UnknownColType,
     Boolean,
 )
-from ..abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
-from .base import (
+from data_diff.sqeleton.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
+from data_diff.sqeleton.databases.base import (
     MD5_HEXDIGITS,
     CHECKSUM_HEXDIGITS,
     BaseDialect,

--- a/data_diff/sqeleton/databases/duckdb.py
+++ b/data_diff/sqeleton/databases/duckdb.py
@@ -1,7 +1,7 @@
 from typing import Union
 
-from ..utils import match_regexps
-from ..abcs.database_types import (
+from data_diff.sqeleton.utils import match_regexps
+from data_diff.sqeleton.abcs.database_types import (
     Timestamp,
     TimestampTZ,
     DbPath,
@@ -16,13 +16,13 @@ from ..abcs.database_types import (
     Boolean,
     AbstractTable,
 )
-from ..abcs.mixins import (
+from data_diff.sqeleton.abcs.mixins import (
     AbstractMixin_MD5,
     AbstractMixin_NormalizeValue,
     AbstractMixin_RandomSample,
     AbstractMixin_Regex,
 )
-from .base import (
+from data_diff.sqeleton.databases.base import (
     Database,
     BaseDialect,
     import_helper,
@@ -30,9 +30,9 @@ from .base import (
     ThreadLocalInterpreter,
     TIMESTAMP_PRECISION_POS,
 )
-from .base import MD5_HEXDIGITS, CHECKSUM_HEXDIGITS, Mixin_Schema
-from ..queries.ast_classes import Func, Compilable
-from ..queries.api import code
+from data_diff.sqeleton.databases.base import MD5_HEXDIGITS, CHECKSUM_HEXDIGITS, Mixin_Schema
+from data_diff.sqeleton.queries.ast_classes import Func, Compilable
+from data_diff.sqeleton.queries.api import code
 
 
 @import_helper("duckdb")

--- a/data_diff/sqeleton/databases/mssql.py
+++ b/data_diff/sqeleton/databases/mssql.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from data_diff.sqeleton.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
-from .base import (
+from data_diff.sqeleton.databases.base import (
     CHECKSUM_HEXDIGITS,
     Mixin_OptimizerHints,
     Mixin_RandomSample,
@@ -10,8 +10,8 @@ from .base import (
     ConnectError,
     BaseDialect,
 )
-from .base import Mixin_Schema
-from ..abcs.database_types import (
+from data_diff.sqeleton.databases.base import Mixin_Schema
+from data_diff.sqeleton.abcs.database_types import (
     JSON,
     Timestamp,
     TimestampTZ,

--- a/data_diff/sqeleton/databases/mysql.py
+++ b/data_diff/sqeleton/databases/mysql.py
@@ -1,4 +1,4 @@
-from ..abcs.database_types import (
+from data_diff.sqeleton.abcs.database_types import (
     Datetime,
     Timestamp,
     Float,
@@ -11,15 +11,28 @@ from ..abcs.database_types import (
     Boolean,
     Date,
 )
-from ..abcs.mixins import (
+from data_diff.sqeleton.abcs.mixins import (
     AbstractMixin_MD5,
     AbstractMixin_NormalizeValue,
     AbstractMixin_Regex,
     AbstractMixin_RandomSample,
 )
-from .base import Mixin_OptimizerHints, ThreadedDatabase, import_helper, ConnectError, BaseDialect, Compilable
-from .base import MD5_HEXDIGITS, CHECKSUM_HEXDIGITS, TIMESTAMP_PRECISION_POS, Mixin_Schema, Mixin_RandomSample
-from ..queries.ast_classes import BinBoolOp
+from data_diff.sqeleton.databases.base import (
+    Mixin_OptimizerHints,
+    ThreadedDatabase,
+    import_helper,
+    ConnectError,
+    BaseDialect,
+    Compilable,
+)
+from data_diff.sqeleton.databases.base import (
+    MD5_HEXDIGITS,
+    CHECKSUM_HEXDIGITS,
+    TIMESTAMP_PRECISION_POS,
+    Mixin_Schema,
+    Mixin_RandomSample,
+)
+from data_diff.sqeleton.queries.ast_classes import BinBoolOp
 
 
 @import_helper("mysql")

--- a/data_diff/sqeleton/databases/oracle.py
+++ b/data_diff/sqeleton/databases/oracle.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
-from ..utils import match_regexps
-from ..abcs.database_types import (
+from data_diff.sqeleton.utils import match_regexps
+from data_diff.sqeleton.abcs.database_types import (
     Decimal,
     Float,
     Text,
@@ -14,10 +14,10 @@ from ..abcs.database_types import (
     TimestampTZ,
     FractionalType,
 )
-from ..abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_Schema
-from ..abcs import Compilable
-from ..queries import this, table, SKIP
-from .base import (
+from data_diff.sqeleton.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_Schema
+from data_diff.sqeleton.abcs import Compilable
+from data_diff.sqeleton.queries import this, table, SKIP
+from data_diff.sqeleton.databases.base import (
     BaseDialect,
     Mixin_OptimizerHints,
     ThreadedDatabase,
@@ -26,7 +26,7 @@ from .base import (
     QueryError,
     Mixin_RandomSample,
 )
-from .base import TIMESTAMP_PRECISION_POS
+from data_diff.sqeleton.databases.base import TIMESTAMP_PRECISION_POS
 
 SESSION_TIME_ZONE = None  # Changed by the tests
 

--- a/data_diff/sqeleton/databases/postgresql.py
+++ b/data_diff/sqeleton/databases/postgresql.py
@@ -1,5 +1,5 @@
 from typing import List
-from ..abcs.database_types import (
+from data_diff.sqeleton.abcs.database_types import (
     DbPath,
     JSON,
     Timestamp,
@@ -14,9 +14,15 @@ from ..abcs.database_types import (
     Boolean,
     Date,
 )
-from ..abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
-from .base import BaseDialect, ThreadedDatabase, import_helper, ConnectError, Mixin_Schema
-from .base import MD5_HEXDIGITS, CHECKSUM_HEXDIGITS, _CHECKSUM_BITSIZE, TIMESTAMP_PRECISION_POS, Mixin_RandomSample
+from data_diff.sqeleton.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
+from data_diff.sqeleton.databases.base import BaseDialect, ThreadedDatabase, import_helper, ConnectError, Mixin_Schema
+from data_diff.sqeleton.databases.base import (
+    MD5_HEXDIGITS,
+    CHECKSUM_HEXDIGITS,
+    _CHECKSUM_BITSIZE,
+    TIMESTAMP_PRECISION_POS,
+    Mixin_RandomSample,
+)
 
 SESSION_TIME_ZONE = None  # Changed by the tests
 

--- a/data_diff/sqeleton/databases/presto.py
+++ b/data_diff/sqeleton/databases/presto.py
@@ -1,9 +1,9 @@
 from functools import partial
 import re
 
-from ..utils import match_regexps
+from data_diff.sqeleton.utils import match_regexps
 
-from ..abcs.database_types import (
+from data_diff.sqeleton.abcs.database_types import (
     Timestamp,
     TimestampTZ,
     Integer,
@@ -18,9 +18,16 @@ from ..abcs.database_types import (
     TemporalType,
     Boolean,
 )
-from ..abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
-from .base import BaseDialect, Database, import_helper, ThreadLocalInterpreter, Mixin_Schema, Mixin_RandomSample
-from .base import (
+from data_diff.sqeleton.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
+from data_diff.sqeleton.databases.base import (
+    BaseDialect,
+    Database,
+    import_helper,
+    ThreadLocalInterpreter,
+    Mixin_Schema,
+    Mixin_RandomSample,
+)
+from data_diff.sqeleton.databases.base import (
     MD5_HEXDIGITS,
     CHECKSUM_HEXDIGITS,
     TIMESTAMP_PRECISION_POS,

--- a/data_diff/sqeleton/databases/redshift.py
+++ b/data_diff/sqeleton/databases/redshift.py
@@ -1,5 +1,5 @@
 from typing import List, Dict
-from ..abcs.database_types import (
+from data_diff.sqeleton.abcs.database_types import (
     Float,
     JSON,
     TemporalType,
@@ -7,8 +7,8 @@ from ..abcs.database_types import (
     DbPath,
     TimestampTZ,
 )
-from ..abcs.mixins import AbstractMixin_MD5
-from .postgresql import (
+from data_diff.sqeleton.abcs.mixins import AbstractMixin_MD5
+from data_diff.sqeleton.databases.postgresql import (
     PostgreSQL,
     MD5_HEXDIGITS,
     CHECKSUM_HEXDIGITS,

--- a/data_diff/sqeleton/databases/snowflake.py
+++ b/data_diff/sqeleton/databases/snowflake.py
@@ -1,7 +1,7 @@
 from typing import Union, List
 import logging
 
-from ..abcs.database_types import (
+from data_diff.sqeleton.abcs.database_types import (
     Timestamp,
     TimestampTZ,
     Decimal,
@@ -13,15 +13,15 @@ from ..abcs.database_types import (
     Boolean,
     Date,
 )
-from ..abcs.mixins import (
+from data_diff.sqeleton.abcs.mixins import (
     AbstractMixin_MD5,
     AbstractMixin_NormalizeValue,
     AbstractMixin_Schema,
     AbstractMixin_TimeTravel,
 )
-from ..abcs import Compilable
+from data_diff.sqeleton.abcs import Compilable
 from data_diff.sqeleton.queries import table, this, SKIP, code
-from .base import (
+from data_diff.sqeleton.databases.base import (
     BaseDialect,
     ConnectError,
     Database,

--- a/data_diff/sqeleton/databases/trino.py
+++ b/data_diff/sqeleton/databases/trino.py
@@ -1,7 +1,7 @@
-from ..abcs.database_types import TemporalType, ColType_UUID
-from . import presto
-from .base import import_helper
-from .base import TIMESTAMP_PRECISION_POS
+from data_diff.sqeleton.abcs.database_types import TemporalType, ColType_UUID
+from data_diff.sqeleton.databases import presto
+from data_diff.sqeleton.databases.base import import_helper
+from data_diff.sqeleton.databases.base import TIMESTAMP_PRECISION_POS
 
 
 @import_helper("trino")

--- a/data_diff/sqeleton/databases/vertica.py
+++ b/data_diff/sqeleton/databases/vertica.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from ..utils import match_regexps
-from .base import (
+from data_diff.sqeleton.utils import match_regexps
+from data_diff.sqeleton.databases.base import (
     CHECKSUM_HEXDIGITS,
     MD5_HEXDIGITS,
     TIMESTAMP_PRECISION_POS,
@@ -13,7 +13,7 @@ from .base import (
     import_helper,
     Mixin_RandomSample,
 )
-from ..abcs.database_types import (
+from data_diff.sqeleton.abcs.database_types import (
     Decimal,
     Float,
     FractionalType,
@@ -25,9 +25,9 @@ from ..abcs.database_types import (
     Boolean,
     ColType_UUID,
 )
-from ..abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_Schema
-from ..abcs import Compilable
-from ..queries import table, this, SKIP
+from data_diff.sqeleton.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_Schema
+from data_diff.sqeleton.abcs import Compilable
+from data_diff.sqeleton.queries import table, this, SKIP
 
 
 @import_helper("vertica")

--- a/data_diff/sqeleton/queries/__init__.py
+++ b/data_diff/sqeleton/queries/__init__.py
@@ -1,5 +1,5 @@
-from .compiler import Compiler, CompileError
-from .api import (
+from data_diff.sqeleton.queries.compiler import Compiler, CompileError
+from data_diff.sqeleton.queries.api import (
     this,
     join,
     outerjoin,
@@ -21,5 +21,5 @@ from .api import (
     current_timestamp,
     code,
 )
-from .ast_classes import Expr, ExprNode, Select, Count, BinOp, Explain, In, Code, Column
-from .extras import Checksum, NormalizeAsString, ApplyFuncAndNormalizeAsString
+from data_diff.sqeleton.queries.ast_classes import Expr, ExprNode, Select, Count, BinOp, Explain, In, Code, Column
+from data_diff.sqeleton.queries.extras import Checksum, NormalizeAsString, ApplyFuncAndNormalizeAsString

--- a/data_diff/sqeleton/queries/api.py
+++ b/data_diff/sqeleton/queries/api.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
-from ..utils import CaseAwareMapping, CaseSensitiveDict
-from .ast_classes import *
-from .base import args_as_tuple
+from data_diff.sqeleton.utils import CaseAwareMapping, CaseSensitiveDict
+from data_diff.sqeleton.queries.ast_classes import *
+from data_diff.sqeleton.queries.base import args_as_tuple
 
 
 this = This()

--- a/data_diff/sqeleton/queries/ast_classes.py
+++ b/data_diff/sqeleton/queries/ast_classes.py
@@ -5,14 +5,14 @@ from typing import Any, Generator, List, Optional, Sequence, Type, Union, Dict
 from runtype import dataclass
 from typing_extensions import Self
 
-from ..utils import join_iter, ArithString
-from ..abcs import Compilable
-from ..abcs.database_types import AbstractTable
-from ..abcs.mixins import AbstractMixin_Regex, AbstractMixin_TimeTravel
-from ..schema import Schema
+from data_diff.sqeleton.utils import join_iter, ArithString
+from data_diff.sqeleton.abcs import Compilable
+from data_diff.sqeleton.abcs.database_types import AbstractTable
+from data_diff.sqeleton.abcs.mixins import AbstractMixin_Regex, AbstractMixin_TimeTravel
+from data_diff.sqeleton.schema import Schema
 
-from .compiler import Compiler, cv_params, Root, CompileError
-from .base import SKIP, DbPath, args_as_tuple, SqeletonError
+from data_diff.sqeleton.queries.compiler import Compiler, cv_params, Root, CompileError
+from data_diff.sqeleton.queries.base import SKIP, DbPath, args_as_tuple, SqeletonError
 
 
 class QueryBuilderError(SqeletonError):

--- a/data_diff/sqeleton/queries/base.py
+++ b/data_diff/sqeleton/queries/base.py
@@ -1,7 +1,7 @@
 from typing import Generator
 
-from ..abcs import DbPath, DbKey
-from ..schema import Schema
+from data_diff.sqeleton.abcs import DbPath, DbKey
+from data_diff.sqeleton.schema import Schema
 
 
 class _SKIP:

--- a/data_diff/sqeleton/queries/compiler.py
+++ b/data_diff/sqeleton/queries/compiler.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Sequence, List
 from runtype import dataclass
 from typing_extensions import Self
 
-from ..utils import ArithString
-from ..abcs import AbstractDatabase, AbstractDialect, DbPath, AbstractCompiler, Compilable
+from data_diff.sqeleton.utils import ArithString
+from data_diff.sqeleton.abcs import AbstractDatabase, AbstractDialect, DbPath, AbstractCompiler, Compilable
 
 import contextvars
 
@@ -44,7 +44,7 @@ class Compiler(AbstractCompiler):
             cv_params.set(params)
 
         if self.root and isinstance(elem, Compilable) and not isinstance(elem, Root):
-            from .ast_classes import Select
+            from data_diff.sqeleton.queries.ast_classes import Select
 
             elem = Select(columns=[elem])
 

--- a/data_diff/sqeleton/queries/extras.py
+++ b/data_diff/sqeleton/queries/extras.py
@@ -3,10 +3,10 @@
 from typing import Callable, Sequence
 from runtype import dataclass
 
-from ..abcs.database_types import ColType, Native_UUID
+from data_diff.sqeleton.abcs.database_types import ColType, Native_UUID
 
-from .compiler import Compiler
-from .ast_classes import Expr, ExprNode, Concat, Code
+from data_diff.sqeleton.queries.compiler import Compiler
+from data_diff.sqeleton.queries.ast_classes import Expr, ExprNode, Concat, Code
 
 
 @dataclass

--- a/data_diff/sqeleton/repl.py
+++ b/data_diff/sqeleton/repl.py
@@ -3,7 +3,7 @@ import logging
 
 # logging.basicConfig(level=logging.DEBUG)
 
-from . import connect
+from data_diff.sqeleton import connect
 
 import sys
 

--- a/data_diff/sqeleton/schema.py
+++ b/data_diff/sqeleton/schema.py
@@ -1,7 +1,7 @@
 import logging
 
-from .utils import CaseAwareMapping, CaseInsensitiveDict, CaseSensitiveDict
-from .abcs import AbstractDatabase, DbPath
+from data_diff.sqeleton.utils import CaseAwareMapping, CaseInsensitiveDict, CaseSensitiveDict
+from data_diff.sqeleton.abcs import AbstractDatabase, DbPath
 
 logger = logging.getLogger("schema")
 

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -6,7 +6,7 @@ from itertools import product
 from runtype import dataclass
 from typing_extensions import Self
 
-from .utils import safezip, Vector
+from data_diff.utils import safezip, Vector
 from data_diff.sqeleton.utils import ArithString, split_space
 from data_diff.sqeleton.databases import Database, DbPath, DbKey, DbTime
 from data_diff.sqeleton.schema import Schema, create_schema

--- a/data_diff/tracking.py
+++ b/data_diff/tracking.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 import toml
 from rich import get_console
 
-from .version import __version__
+from data_diff.version import __version__
 
 TRACK_URL = "https://hosted.rudderlabs.com/v1/track"
 START_EVENT = "os_diff_run_start"

--- a/data_diff/utils.py
+++ b/data_diff/utils.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from packaging.version import parse as parse_version
 import requests
 from tabulate import tabulate
-from .version import __version__
+from data_diff.version import __version__
 from rich.status import Status
 
 

--- a/docs/new-database-driver-guide.rst
+++ b/docs/new-database-driver-guide.rst
@@ -51,7 +51,7 @@ Instead, they should be imported and initialized within a function. Example:
 
 ::
 
-    from .base import import_helper
+    from data_diff.base import import_helper
 
     @import_helper("postgresql")
     def import_postgresql():

--- a/tests/common.py
+++ b/tests/common.py
@@ -63,7 +63,7 @@ logging.getLogger("table_segment").setLevel(level)
 logging.getLogger("database").setLevel(level)
 
 try:
-    from .local_settings import *
+    from tests.local_settings import *
 except ImportError:
     pass  # No local settings
 

--- a/tests/sqeleton/common.py
+++ b/tests/sqeleton/common.py
@@ -48,7 +48,7 @@ logging.basicConfig(level=level)
 logging.getLogger("database").setLevel(level)
 
 try:
-    from .local_settings import *
+    from tests.sqeleton.local_settings import *
 except ImportError:
     pass  # No local settings
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,7 @@ from data_diff import diff_tables, connect_to_table, Algorithm
 from data_diff.databases import MySQL
 from data_diff.sqeleton.queries import table, commit
 
-from .common import TEST_MYSQL_CONN_STRING, get_conn, random_table_suffix, DiffTestCase
+from tests.common import TEST_MYSQL_CONN_STRING, get_conn, random_table_suffix, DiffTestCase
 
 
 class TestApi(DiffTestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta
 
 from data_diff.sqeleton.queries import commit, current_timestamp
 
-from .common import DiffTestCase, CONN_STRINGS
-from .test_diff_tables import test_each_database
+from tests.common import DiffTestCase, CONN_STRINGS
+from tests.test_diff_tables import test_each_database
 
 
 def run_datadiff_cli(*args):

--- a/tests/test_database_types.py
+++ b/tests/test_database_types.py
@@ -22,7 +22,7 @@ from data_diff.query_utils import drop_table
 from data_diff.utils import accumulate
 from data_diff.hashdiff_tables import HashDiffer, DEFAULT_BISECTION_THRESHOLD
 from data_diff.table_segment import TableSegment
-from .common import (
+from tests.common import (
     CONN_STRINGS,
     N_SAMPLES,
     N_THREADS,

--- a/tests/test_dbt.py
+++ b/tests/test_dbt.py
@@ -22,7 +22,7 @@ from data_diff.dbt import (
 from data_diff.dbt_parser import (
     TDatadiffConfig,
 )
-from .test_cli import run_datadiff_cli
+from tests.test_cli import run_datadiff_cli
 
 
 class TestDbtDiffer(unittest.TestCase):

--- a/tests/test_diff_tables.py
+++ b/tests/test_diff_tables.py
@@ -11,7 +11,7 @@ from data_diff.joindiff_tables import JoinDiffer
 from data_diff.table_segment import TableSegment, split_space, Vector
 from data_diff import databases as db
 
-from .common import str_to_checksum, test_each_database_in_list, DiffTestCase, table_segment
+from tests.common import str_to_checksum, test_each_database_in_list, DiffTestCase, table_segment
 
 
 TEST_DATABASES = {

--- a/tests/test_joindiff.py
+++ b/tests/test_joindiff.py
@@ -7,9 +7,9 @@ from data_diff.table_segment import TableSegment
 from data_diff import databases as db
 from data_diff.joindiff_tables import JoinDiffer
 
-from .test_diff_tables import DiffTestCase
+from tests.test_diff_tables import DiffTestCase
 
-from .common import (
+from tests.common import (
     random_table_suffix,
     test_each_database_in_list,
 )

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -4,7 +4,7 @@ from data_diff.sqeleton.queries import table, commit
 
 from data_diff import TableSegment, HashDiffer
 from data_diff import databases as db
-from .common import get_conn, random_table_suffix
+from tests.common import get_conn, random_table_suffix
 
 
 class TestUUID(unittest.TestCase):


### PR DESCRIPTION
In order to use the same convention across the code (now: mixed relative & absolute imports).

Besides, this helps to easily grep the imports, so as to use IDEs features to auto-import modules on use.

Besides, the import sorters typically convert this to fully qualified names anyway.

**THERE IS NO CHANGE IN FUNCTIONALITY.**