### PR TITLE
Issue 603 - inconsistent information_schema.columns types

### DIFF
--- a/data_diff/sqeleton/databases/mysql.py
+++ b/data_diff/sqeleton/databases/mysql.py
@@ -152,7 +152,7 @@ class MySQL(ThreadedDatabase):
         mysql = import_mysql()
         try:
             conn = mysql.connect(charset="utf8mb4", use_unicode=True, **self._args)
-            conn.set_charset_collation(charset="utf8mb4", collation='utf8mb4_0900_ai_ci')
+            conn.set_charset_collation(charset="utf8mb4", collation="utf8mb4_0900_ai_ci")
             return conn
 
         except mysql.Error as e:


### PR DESCRIPTION
For **_some_** mysql users, `select DATA_TYPE FROM information_schema.columns` is returning b'str'

It seems collation \~can\~ affect the QueryResult types returned by `mysql-connector-python`. Strings **_can_** be returned as byte strings (or byte arrays??) when using `_bin` collations. In addition char_set="utf8" is actually an alias that can cause more inconsistencies.

See:
- https://stackoverflow.com/a/49463021
- https://stackoverflow.com/a/9535736
- https://stackoverflow.com/q/66626792 (exact problem)

This PR explicitly sets the encoding and collation used by the client to (hopefully) resolve #603 -- I'm not able to reproduce that exact scenario, but a similar one when changing the collation locally.
![Screenshot 2023-09-22 at 8 02 56 PM](https://github.com/datafold/data-diff/assets/11282254/617567eb-f2b2-4da7-bea7-e0c0dee7955f)

Note the column level collation setting for "DATA_TYPE", setting it in the client overrides this and any other settings.