### PR TITLE
Convert to `attrs`, remove `runtype`

### DIFF
--- a/data_diff/abcs/compiler.py
+++ b/data_diff/abcs/compiler.py
@@ -1,9 +1,13 @@
 from abc import ABC
 
+import attrs
 
+
+@attrs.define(frozen=False)
 class AbstractCompiler(ABC):
     pass
 
 
+@attrs.define(frozen=False, eq=False)
 class Compilable(ABC):
     pass

--- a/data_diff/abcs/database_types.py
+++ b/data_diff/abcs/database_types.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from typing import Tuple, Union
 from datetime import datetime
 
-from runtype import dataclass
+import attrs
 
 from data_diff.utils import ArithAlphanumeric, ArithUUID, Unknown
 
@@ -13,14 +13,14 @@ DbKey = Union[int, str, bytes, ArithUUID, ArithAlphanumeric]
 DbTime = datetime
 
 
-@dataclass
+@attrs.define(frozen=True)
 class ColType:
     @property
     def supported(self) -> bool:
         return True
 
 
-@dataclass
+@attrs.define(frozen=True)
 class PrecisionType(ColType):
     precision: int
     rounds: Union[bool, Unknown] = Unknown
@@ -50,7 +50,7 @@ class Date(TemporalType):
     pass
 
 
-@dataclass
+@attrs.define(frozen=True)
 class NumericType(ColType):
     # 'precision' signifies how many fractional digits (after the dot) we want to compare
     precision: int
@@ -84,7 +84,7 @@ class Decimal(FractionalType, IKey):  # Snowflake may use Decimal as a key
         return decimal.Decimal
 
 
-@dataclass
+@attrs.define(frozen=True)
 class StringType(ColType):
     python_type = str
 
@@ -122,7 +122,7 @@ class String_VaryingAlphanum(String_Alphanum):
     pass
 
 
-@dataclass
+@attrs.define(frozen=True)
 class String_FixedAlphanum(String_Alphanum):
     length: int
 
@@ -132,7 +132,7 @@ class String_FixedAlphanum(String_Alphanum):
         return self.python_type(value, max_len=self.length)
 
 
-@dataclass
+@attrs.define(frozen=True)
 class Text(StringType):
     @property
     def supported(self) -> bool:
@@ -140,12 +140,12 @@ class Text(StringType):
 
 
 # In majority of DBMSes, it is called JSON/JSONB. Only in Snowflake, it is OBJECT.
-@dataclass
+@attrs.define(frozen=True)
 class JSON(ColType):
     pass
 
 
-@dataclass
+@attrs.define(frozen=True)
 class Array(ColType):
     item_type: ColType
 
@@ -155,21 +155,21 @@ class Array(ColType):
 # For example, in BigQuery:
 # - https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type
 # - https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#struct_literals
-@dataclass
+@attrs.define(frozen=True)
 class Struct(ColType):
     pass
 
 
-@dataclass
+@attrs.define(frozen=True)
 class Integer(NumericType, IKey):
     precision: int = 0
     python_type: type = int
 
-    def __post_init__(self):
+    def __attrs_post_init__(self):
         assert self.precision == 0
 
 
-@dataclass
+@attrs.define(frozen=True)
 class UnknownColType(ColType):
     text: str
 

--- a/data_diff/abcs/database_types.py
+++ b/data_diff/abcs/database_types.py
@@ -26,26 +26,32 @@ class PrecisionType(ColType):
     rounds: Union[bool, Unknown] = Unknown
 
 
+@attrs.define(frozen=True)
 class Boolean(ColType):
     precision = 0
 
 
+@attrs.define(frozen=True)
 class TemporalType(PrecisionType):
     pass
 
 
+@attrs.define(frozen=True)
 class Timestamp(TemporalType):
     pass
 
 
+@attrs.define(frozen=True)
 class TimestampTZ(TemporalType):
     pass
 
 
+@attrs.define(frozen=True)
 class Datetime(TemporalType):
     pass
 
 
+@attrs.define(frozen=True)
 class Date(TemporalType):
     pass
 
@@ -56,14 +62,17 @@ class NumericType(ColType):
     precision: int
 
 
+@attrs.define(frozen=True)
 class FractionalType(NumericType):
     pass
 
 
+@attrs.define(frozen=True)
 class Float(FractionalType):
     python_type = float
 
 
+@attrs.define(frozen=True)
 class IKey(ABC):
     "Interface for ColType, for using a column as a key in table."
 
@@ -76,6 +85,7 @@ class IKey(ABC):
         return self.python_type(value)
 
 
+@attrs.define(frozen=True)
 class Decimal(FractionalType, IKey):  # Snowflake may use Decimal as a key
     @property
     def python_type(self) -> type:
@@ -89,22 +99,27 @@ class StringType(ColType):
     python_type = str
 
 
+@attrs.define(frozen=True)
 class ColType_UUID(ColType, IKey):
     python_type = ArithUUID
 
 
+@attrs.define(frozen=True)
 class ColType_Alphanum(ColType, IKey):
     python_type = ArithAlphanumeric
 
 
+@attrs.define(frozen=True)
 class Native_UUID(ColType_UUID):
     pass
 
 
+@attrs.define(frozen=True)
 class String_UUID(ColType_UUID, StringType):
     pass
 
 
+@attrs.define(frozen=True)
 class String_Alphanum(ColType_Alphanum, StringType):
     @staticmethod
     def test_value(value: str) -> bool:
@@ -118,6 +133,7 @@ class String_Alphanum(ColType_Alphanum, StringType):
         return self.python_type(value)
 
 
+@attrs.define(frozen=True)
 class String_VaryingAlphanum(String_Alphanum):
     pass
 

--- a/data_diff/abcs/database_types.py
+++ b/data_diff/abcs/database_types.py
@@ -15,7 +15,9 @@ DbTime = datetime
 
 @dataclass
 class ColType:
-    supported = True
+    @property
+    def supported(self) -> bool:
+        return True
 
 
 @dataclass
@@ -132,7 +134,9 @@ class String_FixedAlphanum(String_Alphanum):
 
 @dataclass
 class Text(StringType):
-    supported = False
+    @property
+    def supported(self) -> bool:
+        return False
 
 
 # In majority of DBMSes, it is called JSON/JSONB. Only in Snowflake, it is OBJECT.
@@ -169,4 +173,6 @@ class Integer(NumericType, IKey):
 class UnknownColType(ColType):
     text: str
 
-    supported = False
+    @property
+    def supported(self) -> bool:
+        return False

--- a/data_diff/abcs/mixins.py
+++ b/data_diff/abcs/mixins.py
@@ -1,4 +1,7 @@
 from abc import ABC, abstractmethod
+
+import attrs
+
 from data_diff.abcs.database_types import (
     Array,
     TemporalType,
@@ -13,10 +16,12 @@ from data_diff.abcs.database_types import (
 from data_diff.abcs.compiler import Compilable
 
 
+@attrs.define(frozen=False)
 class AbstractMixin(ABC):
     "A mixin for a database dialect"
 
 
+@attrs.define(frozen=False)
 class AbstractMixin_NormalizeValue(AbstractMixin):
     @abstractmethod
     def to_comparable(self, value: str, coltype: ColType) -> str:
@@ -108,6 +113,7 @@ class AbstractMixin_NormalizeValue(AbstractMixin):
         return self.to_string(value)
 
 
+@attrs.define(frozen=False)
 class AbstractMixin_MD5(AbstractMixin):
     """Methods for calculating an MD6 hash as an integer."""
 
@@ -116,6 +122,7 @@ class AbstractMixin_MD5(AbstractMixin):
         "Provide SQL for computing md5 and returning an int"
 
 
+@attrs.define(frozen=False)
 class AbstractMixin_Schema(AbstractMixin):
     """Methods for querying the database schema
 
@@ -134,6 +141,7 @@ class AbstractMixin_Schema(AbstractMixin):
         """
 
 
+@attrs.define(frozen=False)
 class AbstractMixin_RandomSample(AbstractMixin):
     @abstractmethod
     def random_sample_n(self, tbl: str, size: int) -> str:
@@ -151,6 +159,7 @@ class AbstractMixin_RandomSample(AbstractMixin):
     #     """
 
 
+@attrs.define(frozen=False)
 class AbstractMixin_TimeTravel(AbstractMixin):
     @abstractmethod
     def time_travel(
@@ -173,6 +182,7 @@ class AbstractMixin_TimeTravel(AbstractMixin):
         """
 
 
+@attrs.define(frozen=False)
 class AbstractMixin_OptimizerHints(AbstractMixin):
     @abstractmethod
     def optimizer_hints(self, optimizer_hints: str) -> str:

--- a/data_diff/cloud/datafold_api.py
+++ b/data_diff/cloud/datafold_api.py
@@ -1,9 +1,9 @@
 import base64
-import dataclasses
 import enum
 import time
 from typing import Any, Dict, List, Optional, Type, Tuple
 
+import attrs
 import pydantic
 import requests
 from typing_extensions import Self
@@ -178,13 +178,13 @@ class TCloudApiDataSourceTestResult(pydantic.BaseModel):
     result: Optional[TCloudDataSourceTestResult]
 
 
-@dataclasses.dataclass
+@attrs.define(frozen=True)
 class DatafoldAPI:
     api_key: str
     host: str = "https://app.datafold.com"
     timeout: int = 30
 
-    def __post_init__(self):
+    def __attrs_post_init__(self):
         self.host = self.host.rstrip("/")
         self.headers = {
             "Authorization": f"Key {self.api_key}",

--- a/data_diff/databases/_connect.py
+++ b/data_diff/databases/_connect.py
@@ -93,6 +93,7 @@ DATABASE_BY_SCHEME = {
 }
 
 
+@attrs.define(frozen=False, init=False)
 class Connect:
     """Provides methods for connecting to a supported database using a URL or connection dict."""
 
@@ -288,6 +289,7 @@ class Connect:
         return db_conf
 
 
+@attrs.define(frozen=False, init=False)
 class Connect_SetUTC(Connect):
     """Provides methods for connecting to a supported database using a URL or connection dict.
 

--- a/data_diff/databases/_connect.py
+++ b/data_diff/databases/_connect.py
@@ -95,6 +95,8 @@ DATABASE_BY_SCHEME = {
 class Connect:
     """Provides methods for connecting to a supported database using a URL or connection dict."""
 
+    database_by_scheme: Dict[str, Database]
+    match_uri_path: Dict[str, MatchUriPath]
     conn_cache: MutableMapping[Hashable, Database]
 
     def __init__(self, database_by_scheme: Dict[str, Database] = DATABASE_BY_SCHEME):

--- a/data_diff/databases/_connect.py
+++ b/data_diff/databases/_connect.py
@@ -3,10 +3,11 @@ from typing import Hashable, MutableMapping, Type, Optional, Union, Dict
 from itertools import zip_longest
 from contextlib import suppress
 import weakref
+
+import attrs
 import dsnparse
 import toml
 
-from runtype import dataclass
 from typing_extensions import Self
 
 from data_diff.databases.base import Database, ThreadedDatabase
@@ -25,7 +26,7 @@ from data_diff.databases.duckdb import DuckDB
 from data_diff.databases.mssql import MsSQL
 
 
-@dataclass
+@attrs.define(frozen=True)
 class MatchUriPath:
     database_cls: Type[Database]
 

--- a/data_diff/databases/_connect.py
+++ b/data_diff/databases/_connect.py
@@ -98,6 +98,7 @@ class Connect:
     conn_cache: MutableMapping[Hashable, Database]
 
     def __init__(self, database_by_scheme: Dict[str, Database] = DATABASE_BY_SCHEME):
+        super().__init__()
         self.database_by_scheme = database_by_scheme
         self.match_uri_path = {name: MatchUriPath(cls) for name, cls in database_by_scheme.items()}
         self.conn_cache = weakref.WeakValueDictionary()

--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -815,7 +815,7 @@ T = TypeVar("T", bound=BaseDialect)
 @dataclass
 class QueryResult:
     rows: list
-    columns: list = None
+    columns: Optional[list] = None
 
     def __iter__(self):
         return iter(self.rows)

--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -180,6 +180,7 @@ class ThreadLocalInterpreter:
     """
 
     def __init__(self, compiler: Compiler, gen: Generator):
+        super().__init__()
         self.gen = gen
         self.compiler = compiler
 
@@ -1109,6 +1110,7 @@ class ThreadedDatabase(Database):
     """
 
     def __init__(self, thread_count=1):
+        super().__init__()
         self._init_error = None
         self._queue = ThreadPoolExecutor(thread_count, initializer=self.set_conn)
         self.thread_local = threading.local()

--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -1,6 +1,6 @@
 import abc
 import functools
-from dataclasses import field
+import random
 from datetime import datetime
 import math
 import sys
@@ -14,7 +14,7 @@ from uuid import UUID
 import decimal
 import contextvars
 
-from runtype import dataclass
+import attrs
 from typing_extensions import Self
 
 from data_diff.abcs.compiler import AbstractCompiler
@@ -90,12 +90,7 @@ class CompileError(Exception):
     pass
 
 
-# TODO: remove once switched to attrs, where ForwardRef[]/strings are resolved.
-class _RuntypeHackToFixCicularRefrencedDatabase:
-    dialect: "BaseDialect"
-
-
-@dataclass
+@attrs.define(frozen=True)
 class Compiler(AbstractCompiler):
     """
     Compiler bears the context for a single compilation.
@@ -107,16 +102,16 @@ class Compiler(AbstractCompiler):
     # Database is needed to normalize tables. Dialect is needed for recursive compilations.
     # In theory, it is many-to-many relations: e.g. a generic ODBC driver with multiple dialects.
     # In practice, we currently bind the dialects to the specific database classes.
-    database: _RuntypeHackToFixCicularRefrencedDatabase
+    database: "Database"
 
     in_select: bool = False  # Compilation runtime flag
     in_join: bool = False  # Compilation runtime flag
 
-    _table_context: List = field(default_factory=list)  # List[ITable]
-    _subqueries: Dict[str, Any] = field(default_factory=dict)  # XXX not thread-safe
+    _table_context: List = attrs.field(factory=list)  # List[ITable]
+    _subqueries: Dict[str, Any] = attrs.field(factory=dict)  # XXX not thread-safe
     root: bool = True
 
-    _counter: List = field(default_factory=lambda: [0])
+    _counter: List = attrs.field(factory=lambda: [0])
 
     @property
     def dialect(self) -> "BaseDialect":
@@ -136,7 +131,7 @@ class Compiler(AbstractCompiler):
         return self.database.dialect.parse_table_name(table_name)
 
     def add_table_context(self, *tables: Sequence, **kw) -> Self:
-        return self.replace(_table_context=self._table_context + list(tables), **kw)
+        return attrs.evolve(self, table_context=self._table_context + list(tables), **kw)
 
 
 def parse_table_name(t):
@@ -271,7 +266,7 @@ class BaseDialect(abc.ABC):
         if elem is None:
             return "NULL"
         elif isinstance(elem, Compilable):
-            return self.render_compilable(compiler.replace(root=False), elem)
+            return self.render_compilable(attrs.evolve(compiler, root=False), elem)
         elif isinstance(elem, str):
             return f"'{elem}'"
         elif isinstance(elem, (int, float)):
@@ -381,7 +376,7 @@ class BaseDialect(abc.ABC):
         return self.quote(elem.name)
 
     def render_cte(self, parent_c: Compiler, elem: Cte) -> str:
-        c: Compiler = parent_c.replace(_table_context=[], in_select=False)
+        c: Compiler = attrs.evolve(parent_c, table_context=[], in_select=False)
         compiled = self.compile(c, elem.source_table)
 
         name = elem.name or parent_c.new_unique_name()
@@ -494,7 +489,7 @@ class BaseDialect(abc.ABC):
         return f"{self.compile(c, elem.source_table)} {self.quote(elem.name)}"
 
     def render_tableop(self, parent_c: Compiler, elem: TableOp) -> str:
-        c: Compiler = parent_c.replace(in_select=False)
+        c: Compiler = attrs.evolve(parent_c, in_select=False)
         table_expr = f"{self.compile(c, elem.table1)} {elem.op} {self.compile(c, elem.table2)}"
         if parent_c.in_select:
             table_expr = f"({table_expr}) {c.new_unique_name()}"
@@ -506,7 +501,7 @@ class BaseDialect(abc.ABC):
         return self.compile(c, elem._get_resolved())
 
     def render_select(self, parent_c: Compiler, elem: Select) -> str:
-        c: Compiler = parent_c.replace(in_select=True)  # .add_table_context(self.table)
+        c: Compiler = attrs.evolve(parent_c, in_select=True)  # .add_table_context(self.table)
         compile_fn = functools.partial(self.compile, c)
 
         columns = ", ".join(map(compile_fn, elem.columns)) if elem.columns else "*"
@@ -544,7 +539,8 @@ class BaseDialect(abc.ABC):
 
     def render_join(self, parent_c: Compiler, elem: Join) -> str:
         tables = [
-            t if isinstance(t, TableAlias) else TableAlias(t, parent_c.new_unique_name()) for t in elem.source_tables
+            t if isinstance(t, TableAlias) else TableAlias(source_table=t, name=parent_c.new_unique_name())
+            for t in elem.source_tables
         ]
         c = parent_c.add_table_context(*tables, in_join=True, in_select=False)
         op = " JOIN " if elem.op is None else f" {elem.op} JOIN "
@@ -577,7 +573,8 @@ class BaseDialect(abc.ABC):
         if isinstance(elem.table, Select) and elem.table.columns is None and elem.table.group_by_exprs is None:
             return self.compile(
                 c,
-                elem.table.replace(
+                attrs.evolve(
+                    elem.table,
                     columns=columns,
                     group_by_exprs=[Code(k) for k in keys],
                     having_exprs=elem.having_exprs,
@@ -589,7 +586,7 @@ class BaseDialect(abc.ABC):
         having_str = (
             " HAVING " + " AND ".join(map(compile_fn, elem.having_exprs)) if elem.having_exprs is not None else ""
         )
-        select = f"SELECT {columns_str} FROM {self.compile(c.replace(in_select=True), elem.table)} GROUP BY {keys_str}{having_str}"
+        select = f"SELECT {columns_str} FROM {self.compile(attrs.evolve(c, in_select=True), elem.table)} GROUP BY {keys_str}{having_str}"
 
         if c.in_select:
             select = f"({select}) {c.new_unique_name()}"
@@ -815,7 +812,7 @@ class BaseDialect(abc.ABC):
 T = TypeVar("T", bound=BaseDialect)
 
 
-@dataclass
+@attrs.define(frozen=True)
 class QueryResult:
     rows: list
     columns: Optional[list] = None
@@ -830,7 +827,7 @@ class QueryResult:
         return self.rows[i]
 
 
-class Database(abc.ABC, _RuntypeHackToFixCicularRefrencedDatabase):
+class Database(abc.ABC):
     """Base abstract class for databases.
 
     Used for providing connection code and implementation specific SQL utilities.

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -223,6 +223,10 @@ class BigQuery(Database):
     CONNECT_URI_PARAMS = ["dataset"]
     dialect = Dialect()
 
+    project: str
+    dataset: str
+    _client: Any
+
     def __init__(self, project, *, dataset, bigquery_credentials=None, **kw):
         super().__init__()
         credentials = bigquery_credentials

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -224,6 +224,7 @@ class BigQuery(Database):
     dialect = Dialect()
 
     def __init__(self, project, *, dataset, bigquery_credentials=None, **kw):
+        super().__init__()
         credentials = bigquery_credentials
         bigquery = import_bigquery()
 

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -1,5 +1,8 @@
 import re
 from typing import Any, List, Union
+
+import attrs
+
 from data_diff.abcs.database_types import (
     ColType,
     Array,
@@ -50,11 +53,13 @@ def import_bigquery_service_account():
     return service_account
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         return f"cast(cast( ('0x' || substr(TO_HEX(md5({s})), 18)) as int64) as numeric)"
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
@@ -99,6 +104,7 @@ class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
         return f"to_json_string({value})"
 
 
+@attrs.define(frozen=False)
 class Mixin_Schema(AbstractMixin_Schema):
     def list_tables(self, table_schema: str, like: Compilable = None) -> Compilable:
         return (
@@ -112,6 +118,7 @@ class Mixin_Schema(AbstractMixin_Schema):
         )
 
 
+@attrs.define(frozen=False)
 class Mixin_TimeTravel(AbstractMixin_TimeTravel):
     def time_travel(
         self,
@@ -139,6 +146,7 @@ class Mixin_TimeTravel(AbstractMixin_TimeTravel):
         )
 
 
+@attrs.define(frozen=False)
 class Dialect(
     BaseDialect, Mixin_Schema, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, AbstractMixin_NormalizeValue
 ):
@@ -218,6 +226,7 @@ class Dialect(
         return tuple(i for i in path if i is not None)
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class BigQuery(Database):
     CONNECT_URI_HELP = "bigquery://<project>/<dataset>"
     CONNECT_URI_PARAMS = ["dataset"]

--- a/data_diff/databases/clickhouse.py
+++ b/data_diff/databases/clickhouse.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type
+from typing import Any, Dict, Optional, Type
 
 from data_diff.databases.base import (
     MD5_HEXDIGITS,
@@ -166,6 +166,8 @@ class Clickhouse(ThreadedDatabase):
     dialect = Dialect()
     CONNECT_URI_HELP = "clickhouse://<user>:<password>@<host>/<database>"
     CONNECT_URI_PARAMS = ["database?"]
+
+    _args: Dict[str, Any]
 
     def __init__(self, *, thread_count: int, **kw):
         super().__init__(thread_count=thread_count)

--- a/data_diff/databases/clickhouse.py
+++ b/data_diff/databases/clickhouse.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, Optional, Type
 
+import attrs
+
 from data_diff.databases.base import (
     MD5_HEXDIGITS,
     CHECKSUM_HEXDIGITS,
@@ -35,12 +37,14 @@ def import_clickhouse():
     return clickhouse_driver
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         substr_idx = 1 + MD5_HEXDIGITS - CHECKSUM_HEXDIGITS
         return f"reinterpretAsUInt128(reverse(unhex(lowerUTF8(substr(hex(MD5({s})), {substr_idx})))))"
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
     def normalize_number(self, value: str, coltype: FractionalType) -> str:
         # If a decimal value has trailing zeros in a fractional part, when casting to string they are dropped.
@@ -99,6 +103,7 @@ class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
         return f"rpad({value}, {TIMESTAMP_PRECISION_POS + 6}, '0')"
 
 
+@attrs.define(frozen=False)
 class Dialect(BaseDialect, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "Clickhouse"
     ROUNDS_ON_PREC_LOSS = False
@@ -162,6 +167,7 @@ class Dialect(BaseDialect, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, A
         return "now()"
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class Clickhouse(ThreadedDatabase):
     dialect = Dialect()
     CONNECT_URI_HELP = "clickhouse://<user>:<password>@<host>/<database>"

--- a/data_diff/databases/databricks.py
+++ b/data_diff/databases/databricks.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, Sequence
+from typing import Any, Dict, Sequence
 import logging
 
 from data_diff.abcs.database_types import (
@@ -103,13 +103,16 @@ class Databricks(ThreadedDatabase):
     CONNECT_URI_HELP = "databricks://:<access_token>@<server_hostname>/<http_path>"
     CONNECT_URI_PARAMS = ["catalog", "schema"]
 
+    catalog: str
+    _args: Dict[str, Any]
+
     def __init__(self, *, thread_count, **kw):
         super().__init__(thread_count=thread_count)
         logging.getLogger("databricks.sql").setLevel(logging.WARNING)
 
         self._args = kw
         self.default_schema = kw.get("schema", "default")
-        self.catalog = self._args.get("catalog", "hive_metastore")
+        self.catalog = kw.get("catalog", "hive_metastore")
 
     def create_connection(self):
         databricks = import_databricks()

--- a/data_diff/databases/databricks.py
+++ b/data_diff/databases/databricks.py
@@ -2,6 +2,8 @@ import math
 from typing import Any, Dict, Sequence
 import logging
 
+import attrs
+
 from data_diff.abcs.database_types import (
     Integer,
     Float,
@@ -34,11 +36,13 @@ def import_databricks():
     return databricks
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         return f"cast(conv(substr(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16, 10) as decimal(38, 0))"
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         """Databricks timestamp contains no more than 6 digits in precision"""
@@ -60,6 +64,7 @@ class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
         return self.to_string(f"cast ({value} as int)")
 
 
+@attrs.define(frozen=False)
 class Dialect(BaseDialect, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "Databricks"
     ROUNDS_ON_PREC_LOSS = True
@@ -98,6 +103,7 @@ class Dialect(BaseDialect, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, A
         return tuple(i for i in path if i is not None)
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class Databricks(ThreadedDatabase):
     dialect = Dialect()
     CONNECT_URI_HELP = "databricks://:<access_token>@<server_hostname>/<http_path>"

--- a/data_diff/databases/databricks.py
+++ b/data_diff/databases/databricks.py
@@ -104,12 +104,12 @@ class Databricks(ThreadedDatabase):
     CONNECT_URI_PARAMS = ["catalog", "schema"]
 
     def __init__(self, *, thread_count, **kw):
+        super().__init__(thread_count=thread_count)
         logging.getLogger("databricks.sql").setLevel(logging.WARNING)
 
         self._args = kw
         self.default_schema = kw.get("schema", "default")
         self.catalog = self._args.get("catalog", "hive_metastore")
-        super().__init__(thread_count=thread_count)
 
     def create_connection(self):
         databricks = import_databricks()

--- a/data_diff/databases/duckdb.py
+++ b/data_diff/databases/duckdb.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, Union
 
+import attrs
+
 from data_diff.utils import match_regexps
 from data_diff.abcs.database_types import (
     Timestamp,
@@ -40,11 +42,13 @@ def import_duckdb():
     return duckdb
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         return f"('0x' || SUBSTRING(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS},{CHECKSUM_HEXDIGITS}))::BIGINT"
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         # It's precision 6 by default. If precision is less than 6 -> we remove the trailing numbers.
@@ -60,6 +64,7 @@ class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
         return self.to_string(f"{value}::INTEGER")
 
 
+@attrs.define(frozen=False)
 class Mixin_RandomSample(AbstractMixin_RandomSample):
     def random_sample_n(self, tbl: ITable, size: int) -> ITable:
         return code("SELECT * FROM ({tbl}) USING SAMPLE {size};", tbl=tbl, size=size)
@@ -68,6 +73,7 @@ class Mixin_RandomSample(AbstractMixin_RandomSample):
         return code("SELECT * FROM ({tbl}) USING SAMPLE {percent}%;", tbl=tbl, percent=int(100 * ratio))
 
 
+@attrs.define(frozen=False)
 class Dialect(
     BaseDialect, Mixin_Schema, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, AbstractMixin_NormalizeValue
 ):
@@ -131,14 +137,15 @@ class Dialect(
         return "current_timestamp"
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class DuckDB(Database):
     dialect = Dialect()
     SUPPORTS_UNIQUE_CONSTAINT = False  # Temporary, until we implement it
     CONNECT_URI_HELP = "duckdb://<dbname>@<filepath>"
     CONNECT_URI_PARAMS = ["database", "dbpath"]
 
-    _args: Dict[str, Any]
-    _conn: Any
+    _args: Dict[str, Any] = attrs.field(init=False)
+    _conn: Any = attrs.field(init=False)
 
     def __init__(self, **kw):
         super().__init__()

--- a/data_diff/databases/duckdb.py
+++ b/data_diff/databases/duckdb.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Any, Dict, Union
 
 from data_diff.utils import match_regexps
 from data_diff.abcs.database_types import (
@@ -134,14 +134,17 @@ class Dialect(
 class DuckDB(Database):
     dialect = Dialect()
     SUPPORTS_UNIQUE_CONSTAINT = False  # Temporary, until we implement it
-    default_schema = "main"
     CONNECT_URI_HELP = "duckdb://<dbname>@<filepath>"
     CONNECT_URI_PARAMS = ["database", "dbpath"]
+
+    _args: Dict[str, Any]
+    _conn: Any
 
     def __init__(self, **kw):
         super().__init__()
         self._args = kw
         self._conn = self.create_connection()
+        self.default_schema = "main"
 
     @property
     def is_autocommit(self) -> bool:

--- a/data_diff/databases/duckdb.py
+++ b/data_diff/databases/duckdb.py
@@ -139,6 +139,7 @@ class DuckDB(Database):
     CONNECT_URI_PARAMS = ["database", "dbpath"]
 
     def __init__(self, **kw):
+        super().__init__()
         self._args = kw
         self._conn = self.create_connection()
 

--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 from data_diff.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
 from data_diff.databases.base import (
     CHECKSUM_HEXDIGITS,
@@ -160,9 +160,11 @@ class Dialect(
 
 class MsSQL(ThreadedDatabase):
     dialect = Dialect()
-    #
     CONNECT_URI_HELP = "mssql://<user>:<password>@<host>/<database>/<schema>"
     CONNECT_URI_PARAMS = ["database", "schema"]
+
+    default_database: str
+    _args: Dict[str, Any]
 
     def __init__(self, host, port, user, password, *, database, thread_count, **kw):
         args = dict(server=host, port=port, database=database, user=user, password=password, **kw)

--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -1,4 +1,7 @@
 from typing import Any, Dict, Optional
+
+import attrs
+
 from data_diff.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
 from data_diff.databases.base import (
     CHECKSUM_HEXDIGITS,
@@ -34,6 +37,7 @@ def import_mssql():
     return pyodbc
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.precision > 0:
@@ -53,11 +57,13 @@ class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
         return f"FORMAT({value}, 'N{coltype.precision}')"
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         return f"convert(bigint, convert(varbinary, '0x' + RIGHT(CONVERT(NVARCHAR(32), HashBytes('MD5', {s}), 2), {CHECKSUM_HEXDIGITS}), 1))"
 
 
+@attrs.define(frozen=False)
 class Dialect(
     BaseDialect,
     Mixin_Schema,
@@ -158,6 +164,7 @@ class Dialect(
         return f"VALUES {values}"
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class MsSQL(ThreadedDatabase):
     dialect = Dialect()
     CONNECT_URI_HELP = "mssql://<user>:<password>@<host>/<database>/<schema>"

--- a/data_diff/databases/mysql.py
+++ b/data_diff/databases/mysql.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from data_diff.abcs.database_types import (
     Datetime,
     Timestamp,
@@ -136,6 +138,8 @@ class MySQL(ThreadedDatabase):
     SUPPORTS_UNIQUE_CONSTAINT = True
     CONNECT_URI_HELP = "mysql://<user>:<password>@<host>/<database>"
     CONNECT_URI_PARAMS = ["database?"]
+
+    _args: Dict[str, Any]
 
     def __init__(self, *, thread_count, **kw):
         super().__init__(thread_count=thread_count)

--- a/data_diff/databases/mysql.py
+++ b/data_diff/databases/mysql.py
@@ -138,9 +138,8 @@ class MySQL(ThreadedDatabase):
     CONNECT_URI_PARAMS = ["database?"]
 
     def __init__(self, *, thread_count, **kw):
-        self._args = kw
-
         super().__init__(thread_count=thread_count)
+        self._args = kw
 
         # In MySQL schema and database are synonymous
         try:

--- a/data_diff/databases/mysql.py
+++ b/data_diff/databases/mysql.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict
 
+import attrs
+
 from data_diff.abcs.database_types import (
     Datetime,
     Timestamp,
@@ -42,11 +44,13 @@ def import_mysql():
     return mysql.connector
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         return f"cast(conv(substring(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16, 10) as unsigned)"
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
@@ -62,6 +66,7 @@ class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
         return f"TRIM(CAST({value} AS char))"
 
 
+@attrs.define(frozen=False)
 class Dialect(
     BaseDialect,
     Mixin_Schema,
@@ -132,6 +137,7 @@ class Dialect(
         return "SET @@session.time_zone='+00:00'"
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class MySQL(ThreadedDatabase):
     dialect = Dialect()
     SUPPORTS_ALPHANUMS = False

--- a/data_diff/databases/oracle.py
+++ b/data_diff/databases/oracle.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from data_diff.utils import match_regexps
 from data_diff.abcs.database_types import (
@@ -180,6 +180,8 @@ class Oracle(ThreadedDatabase):
     dialect = Dialect()
     CONNECT_URI_HELP = "oracle://<user>:<password>@<host>/<database>"
     CONNECT_URI_PARAMS = ["database?"]
+
+    kwargs: Dict[str, Any]
 
     def __init__(self, *, host, database, thread_count, **kw):
         super().__init__(thread_count=thread_count)

--- a/data_diff/databases/oracle.py
+++ b/data_diff/databases/oracle.py
@@ -182,11 +182,9 @@ class Oracle(ThreadedDatabase):
     CONNECT_URI_PARAMS = ["database?"]
 
     def __init__(self, *, host, database, thread_count, **kw):
-        self.kwargs = dict(dsn=f"{host}/{database}" if database else host, **kw)
-
-        self.default_schema = kw.get("user").upper()
-
         super().__init__(thread_count=thread_count)
+        self.kwargs = dict(dsn=f"{host}/{database}" if database else host, **kw)
+        self.default_schema = kw.get("user").upper()
 
     def create_connection(self):
         self._oracle = import_oracle()

--- a/data_diff/databases/oracle.py
+++ b/data_diff/databases/oracle.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Optional
 
+import attrs
+
 from data_diff.utils import match_regexps
 from data_diff.abcs.database_types import (
     Decimal,
@@ -38,6 +40,7 @@ def import_oracle():
     return oracledb
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         # standard_hash is faster than DBMS_CRYPTO.Hash
@@ -45,6 +48,7 @@ class Mixin_MD5(AbstractMixin_MD5):
         return f"to_number(substr(standard_hash({s}, 'MD5'), 18), 'xxxxxxxxxxxxxxx')"
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
     def normalize_uuid(self, value: str, coltype: ColType_UUID) -> str:
         # Cast is necessary for correct MD5 (trimming not enough)
@@ -68,6 +72,7 @@ class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
         return f"to_char({value}, '{format_str}')"
 
 
+@attrs.define(frozen=False)
 class Mixin_Schema(AbstractMixin_Schema):
     def list_tables(self, table_schema: str, like: Compilable = None) -> Compilable:
         return (
@@ -80,6 +85,7 @@ class Mixin_Schema(AbstractMixin_Schema):
         )
 
 
+@attrs.define(frozen=False)
 class Dialect(
     BaseDialect,
     Mixin_Schema,
@@ -176,6 +182,7 @@ class Dialect(
         return "LOCALTIMESTAMP"
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class Oracle(ThreadedDatabase):
     dialect = Dialect()
     CONNECT_URI_HELP = "oracle://<user>:<password>@<host>/<database>"

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -1,4 +1,7 @@
 from typing import Any, ClassVar, Dict, List, Type
+
+import attrs
+
 from data_diff.abcs.database_types import (
     ColType,
     DbPath,
@@ -36,11 +39,13 @@ def import_postgresql():
     return psycopg2
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         return f"('x' || substring(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}))::bit({_CHECKSUM_BITSIZE})::bigint"
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
@@ -61,6 +66,7 @@ class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
         return f"{value}::text"
 
 
+@attrs.define(frozen=False)
 class PostgresqlDialect(
     BaseDialect, Mixin_Schema, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, AbstractMixin_NormalizeValue
 ):
@@ -120,6 +126,7 @@ class PostgresqlDialect(
         return super().type_repr(t)
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class PostgreSQL(ThreadedDatabase):
     dialect = PostgresqlDialect()
     SUPPORTS_UNIQUE_CONSTAINT = True
@@ -127,6 +134,7 @@ class PostgreSQL(ThreadedDatabase):
     CONNECT_URI_PARAMS = ["database?"]
 
     _args: Dict[str, Any]
+    _conn: Any
 
     def __init__(self, *, thread_count, **kw):
         super().__init__(thread_count=thread_count)

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -128,9 +128,8 @@ class PostgreSQL(ThreadedDatabase):
     default_schema = "public"
 
     def __init__(self, *, thread_count, **kw):
-        self._args = kw
-
         super().__init__(thread_count=thread_count)
+        self._args = kw
 
     def create_connection(self):
         if not self._args:

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -1,5 +1,6 @@
-from typing import List
+from typing import Any, ClassVar, Dict, List, Type
 from data_diff.abcs.database_types import (
+    ColType,
     DbPath,
     JSON,
     Timestamp,
@@ -68,7 +69,7 @@ class PostgresqlDialect(
     SUPPORTS_PRIMARY_KEY = True
     SUPPORTS_INDEXES = True
 
-    TYPE_CLASSES = {
+    TYPE_CLASSES: ClassVar[Dict[str, Type[ColType]]] = {
         # Timestamps
         "timestamp with time zone": TimestampTZ,
         "timestamp without time zone": Timestamp,
@@ -125,11 +126,12 @@ class PostgreSQL(ThreadedDatabase):
     CONNECT_URI_HELP = "postgresql://<user>:<password>@<host>/<database>"
     CONNECT_URI_PARAMS = ["database?"]
 
-    default_schema = "public"
+    _args: Dict[str, Any]
 
     def __init__(self, *, thread_count, **kw):
         super().__init__(thread_count=thread_count)
         self._args = kw
+        self.default_schema = "public"
 
     def create_connection(self):
         if not self._args:

--- a/data_diff/databases/presto.py
+++ b/data_diff/databases/presto.py
@@ -2,6 +2,8 @@ from functools import partial
 import re
 from typing import Any
 
+import attrs
+
 from data_diff.utils import match_regexps
 
 from data_diff.abcs.database_types import (
@@ -51,11 +53,13 @@ def import_presto():
     return prestodb
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         return f"cast(from_base(substr(to_hex(md5(to_utf8({s}))), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16) as decimal(38, 0))"
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
     def normalize_uuid(self, value: str, coltype: ColType_UUID) -> str:
         # Trim doesn't work on CHAR type
@@ -154,6 +158,7 @@ class Dialect(
         return "current_timestamp"
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class Presto(Database):
     dialect = Dialect()
     CONNECT_URI_HELP = "presto://<user>@<host>/<catalog>/<schema>"

--- a/data_diff/databases/presto.py
+++ b/data_diff/databases/presto.py
@@ -161,6 +161,7 @@ class Presto(Database):
     default_schema = "public"
 
     def __init__(self, **kw):
+        super().__init__()
         prestodb = import_presto()
 
         if kw.get("schema"):

--- a/data_diff/databases/presto.py
+++ b/data_diff/databases/presto.py
@@ -1,5 +1,6 @@
 from functools import partial
 import re
+from typing import Any
 
 from data_diff.utils import match_regexps
 
@@ -158,10 +159,11 @@ class Presto(Database):
     CONNECT_URI_HELP = "presto://<user>@<host>/<catalog>/<schema>"
     CONNECT_URI_PARAMS = ["catalog", "schema"]
 
-    default_schema = "public"
+    _conn: Any
 
     def __init__(self, **kw):
         super().__init__()
+        self.default_schema = "public"
         prestodb = import_presto()
 
         if kw.get("schema"):

--- a/data_diff/databases/redshift.py
+++ b/data_diff/databases/redshift.py
@@ -1,4 +1,7 @@
 from typing import ClassVar, List, Dict, Type
+
+import attrs
+
 from data_diff.abcs.database_types import (
     ColType,
     Float,
@@ -19,11 +22,13 @@ from data_diff.databases.postgresql import (
 )
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         return f"strtol(substring(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16)::decimal(38)"
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(Mixin_NormalizeValue):
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
@@ -52,6 +57,7 @@ class Mixin_NormalizeValue(Mixin_NormalizeValue):
         return f"nvl2({value}, json_serialize({value}), NULL)"
 
 
+@attrs.define(frozen=False)
 class Dialect(PostgresqlDialect, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "Redshift"
     TYPE_CLASSES: ClassVar[Dict[str, Type[ColType]]] = {
@@ -75,6 +81,7 @@ class Dialect(PostgresqlDialect, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_
         return super().type_repr(t)
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class Redshift(PostgreSQL):
     dialect = Dialect()
     CONNECT_URI_HELP = "redshift://<user>:<password>@<host>/<database>"

--- a/data_diff/databases/redshift.py
+++ b/data_diff/databases/redshift.py
@@ -1,5 +1,6 @@
-from typing import List, Dict
+from typing import ClassVar, List, Dict, Type
 from data_diff.abcs.database_types import (
+    ColType,
     Float,
     JSON,
     TemporalType,
@@ -53,7 +54,7 @@ class Mixin_NormalizeValue(Mixin_NormalizeValue):
 
 class Dialect(PostgresqlDialect, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "Redshift"
-    TYPE_CLASSES = {
+    TYPE_CLASSES: ClassVar[Dict[str, Type[ColType]]] = {
         **PostgresqlDialect.TYPE_CLASSES,
         "double": Float,
         "real": Float,

--- a/data_diff/databases/snowflake.py
+++ b/data_diff/databases/snowflake.py
@@ -1,6 +1,8 @@
 from typing import Any, Union, List
 import logging
 
+import attrs
+
 from data_diff.abcs.database_types import (
     Timestamp,
     TimestampTZ,
@@ -41,11 +43,13 @@ def import_snowflake():
     return snowflake, serialization, default_backend
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         return f"BITAND(md5_number_lower64({s}), {CHECKSUM_MASK})"
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
@@ -62,6 +66,7 @@ class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
         return self.to_string(f"{value}::int")
 
 
+@attrs.define(frozen=False)
 class Mixin_Schema(AbstractMixin_Schema):
     def table_information(self) -> Compilable:
         return table("INFORMATION_SCHEMA", "TABLES")
@@ -148,6 +153,7 @@ class Dialect(
         return super().type_repr(t)
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class Snowflake(Database):
     dialect = Dialect()
     CONNECT_URI_HELP = "snowflake://<user>:<password>@<account>/<database>/<SCHEMA>?warehouse=<WAREHOUSE>"

--- a/data_diff/databases/snowflake.py
+++ b/data_diff/databases/snowflake.py
@@ -1,4 +1,4 @@
-from typing import Union, List
+from typing import Any, Union, List
 import logging
 
 from data_diff.abcs.database_types import (
@@ -153,6 +153,8 @@ class Snowflake(Database):
     CONNECT_URI_HELP = "snowflake://<user>:<password>@<account>/<database>/<SCHEMA>?warehouse=<WAREHOUSE>"
     CONNECT_URI_PARAMS = ["database", "schema"]
     CONNECT_URI_KWPARAMS = ["warehouse"]
+
+    _conn: Any
 
     def __init__(self, *, schema: str, **kw):
         super().__init__()

--- a/data_diff/databases/snowflake.py
+++ b/data_diff/databases/snowflake.py
@@ -155,6 +155,7 @@ class Snowflake(Database):
     CONNECT_URI_KWPARAMS = ["warehouse"]
 
     def __init__(self, *, schema: str, **kw):
+        super().__init__()
         snowflake, serialization, default_backend = import_snowflake()
         logging.getLogger("snowflake.connector").setLevel(logging.WARNING)
 

--- a/data_diff/databases/trino.py
+++ b/data_diff/databases/trino.py
@@ -40,6 +40,7 @@ class Trino(presto.Presto):
     CONNECT_URI_PARAMS = ["catalog", "schema"]
 
     def __init__(self, **kw):
+        super().__init__()
         trino = import_trino()
 
         if kw.get("schema"):

--- a/data_diff/databases/trino.py
+++ b/data_diff/databases/trino.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import attrs
+
 from data_diff.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
 from data_diff.abcs.database_types import TemporalType, ColType_UUID
 from data_diff.databases import presto
@@ -17,6 +19,7 @@ def import_trino():
 Mixin_MD5 = presto.Mixin_MD5
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(presto.Mixin_NormalizeValue):
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
@@ -36,6 +39,7 @@ class Dialect(presto.Dialect, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5
     name = "Trino"
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class Trino(presto.Presto):
     dialect = Dialect()
     CONNECT_URI_HELP = "trino://<user>@<host>/<catalog>/<schema>"

--- a/data_diff/databases/trino.py
+++ b/data_diff/databases/trino.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from data_diff.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
 from data_diff.abcs.database_types import TemporalType, ColType_UUID
 from data_diff.databases import presto
@@ -38,6 +40,8 @@ class Trino(presto.Presto):
     dialect = Dialect()
     CONNECT_URI_HELP = "trino://<user>@<host>/<catalog>/<schema>"
     CONNECT_URI_PARAMS = ["catalog", "schema"]
+
+    _conn: Any
 
     def __init__(self, **kw):
         super().__init__()

--- a/data_diff/databases/vertica.py
+++ b/data_diff/databases/vertica.py
@@ -159,10 +159,9 @@ class Vertica(ThreadedDatabase):
     default_schema = "public"
 
     def __init__(self, *, thread_count, **kw):
+        super().__init__(thread_count=thread_count)
         self._args = kw
         self._args["AUTOCOMMIT"] = False
-
-        super().__init__(thread_count=thread_count)
 
     def create_connection(self):
         vertica = import_vertica()

--- a/data_diff/databases/vertica.py
+++ b/data_diff/databases/vertica.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List
 
+import attrs
+
 from data_diff.utils import match_regexps
 from data_diff.databases.base import (
     CHECKSUM_HEXDIGITS,
@@ -37,11 +39,13 @@ def import_vertica():
     return vertica_python
 
 
+@attrs.define(frozen=False)
 class Mixin_MD5(AbstractMixin_MD5):
     def md5_as_int(self, s: str) -> str:
         return f"CAST(HEX_TO_INTEGER(SUBSTRING(MD5({s}), {1 + MD5_HEXDIGITS - CHECKSUM_HEXDIGITS})) AS NUMERIC(38, 0))"
 
 
+@attrs.define(frozen=False)
 class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
@@ -151,6 +155,7 @@ class Dialect(
         return "current_timestamp(6)"
 
 
+@attrs.define(frozen=False, init=False, kw_only=True)
 class Vertica(ThreadedDatabase):
     dialect = Dialect()
     CONNECT_URI_HELP = "vertica://<user>:<password>@<host>/<database>"

--- a/data_diff/databases/vertica.py
+++ b/data_diff/databases/vertica.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, Dict, List
 
 from data_diff.utils import match_regexps
 from data_diff.databases.base import (
@@ -156,12 +156,13 @@ class Vertica(ThreadedDatabase):
     CONNECT_URI_HELP = "vertica://<user>:<password>@<host>/<database>"
     CONNECT_URI_PARAMS = ["database?"]
 
-    default_schema = "public"
+    _args: Dict[str, Any]
 
     def __init__(self, *, thread_count, **kw):
         super().__init__(thread_count=thread_count)
         self._args = kw
         self._args["AUTOCOMMIT"] = False
+        self.default_schema = "public"
 
     def create_connection(self):
         vertica = import_vertica()

--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -101,6 +101,8 @@ class DbtParser:
         project_dir_override: Optional[str] = None,
         state: Optional[str] = None,
     ) -> None:
+        super().__init__()
+
         try_set_dbt_flags()
         self.dbt_runner = try_get_dbt_runner()
         self.project_dir = Path(project_dir_override or default_project_dir())

--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -2,7 +2,9 @@ from argparse import Namespace
 from collections import defaultdict
 import json
 from pathlib import Path
-from typing import List, Dict, Tuple, Set, Optional
+from typing import Any, List, Dict, Tuple, Set, Optional
+
+import attrs
 import yaml
 from pydantic import BaseModel
 
@@ -94,7 +96,22 @@ class TDatadiffConfig(BaseModel):
     datasource_id: Optional[int] = None
 
 
+@attrs.define(frozen=False, init=False)
 class DbtParser:
+    dbt_runner: Optional[Any]  # dbt.cli.main.dbtRunner if installed
+    project_dir: Path
+    connection: Dict[str, Any]
+    project_dict: Dict[str, Any]
+    dev_manifest_obj: ManifestJsonConfig
+    prod_manifest_obj: Optional[ManifestJsonConfig]
+    dbt_user_id: str
+    dbt_version: str
+    dbt_project_id: str
+    requires_upper: bool
+    threads: Optional[int]
+    unique_columns: Dict[str, Set[str]]
+    profiles_dir: Path
+
     def __init__(
         self,
         profiles_dir_override: Optional[str] = None,

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -179,6 +179,7 @@ class DiffResultWrapper:
         return json_output
 
 
+@attrs.define(frozen=True)
 class TableDiffer(ThreadBase, ABC):
     bisection_factor = 32
     stats: dict = {}

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -3,14 +3,13 @@
 
 import time
 from abc import ABC, abstractmethod
-from dataclasses import field
 from enum import Enum
 from contextlib import contextmanager
 from operator import methodcaller
 from typing import Dict, Tuple, Iterator, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from runtype import dataclass
+import attrs
 
 from data_diff.info_tree import InfoTree, SegmentInfo
 from data_diff.utils import dbt_diff_string_template, run_as_daemon, safezip, getLogger, truncate_error, Vector
@@ -31,7 +30,7 @@ class Algorithm(Enum):
 DiffResult = Iterator[Tuple[str, tuple]]  # Iterator[Tuple[Literal["+", "-"], tuple]]
 
 
-@dataclass
+@attrs.define(frozen=True)
 class ThreadBase:
     "Provides utility methods for optional threading"
 
@@ -72,7 +71,7 @@ class ThreadBase:
                 f.result()
 
 
-@dataclass
+@attrs.define(frozen=True)
 class DiffStats:
     diff_by_sign: Dict[str, int]
     table1_count: int
@@ -82,12 +81,12 @@ class DiffStats:
     extra_column_diffs: Optional[Dict[str, int]]
 
 
-@dataclass
+@attrs.define(frozen=True)
 class DiffResultWrapper:
     diff: iter  # DiffResult
     info_tree: InfoTree
     stats: dict
-    result_list: list = field(default_factory=list)
+    result_list: list = attrs.field(factory=list)
 
     def __iter__(self):
         yield from self.result_list
@@ -203,7 +202,7 @@ class TableDiffer(ThreadBase, ABC):
 
     def _diff_tables_wrapper(self, table1: TableSegment, table2: TableSegment, info_tree: InfoTree) -> DiffResult:
         if is_tracking_enabled():
-            options = dict(self)
+            options = attrs.asdict(self, recurse=False)
             options["differ_name"] = type(self).__name__
             event_json = create_start_event_json(options)
             run_as_daemon(send_event_json, event_json)

--- a/data_diff/format.py
+++ b/data_diff/format.py
@@ -2,7 +2,7 @@ import collections
 from enum import Enum
 from typing import Any, Optional, List, Dict, Tuple, Type
 
-from runtype import dataclass
+import attrs
 from data_diff.diff_tables import DiffResultWrapper
 from data_diff.abcs.database_types import (
     JSON,
@@ -21,13 +21,15 @@ from data_diff.abcs.database_types import (
 
 
 def jsonify_error(table1: List[str], table2: List[str], dbt_model: str, error: str) -> "FailedDiff":
-    return FailedDiff(
-        status="failed",
-        model=dbt_model,
-        dataset1=table1,
-        dataset2=table2,
-        error=error,
-    ).json()
+    return attrs.asdict(
+        FailedDiff(
+            status="failed",
+            model=dbt_model,
+            dataset1=table1,
+            dataset2=table2,
+            error=error,
+        )
+    )
 
 
 Columns = List[Tuple[str, str, ColType]]
@@ -74,19 +76,21 @@ def jsonify(
         or diff_rows
         or (columns_diff["added"] or columns_diff["removed"] or columns_diff["changed"])
     )
-    return JsonDiff(
-        status="success",
-        result="different" if is_different else "identical",
-        model=dbt_model,
-        dataset1=list(table1.table_path),
-        dataset2=list(table2.table_path),
-        rows=rows,
-        summary=summary,
-        columns=columns,
-    ).json()
+    return attrs.asdict(
+        JsonDiff(
+            status="success",
+            result="different" if is_different else "identical",
+            model=dbt_model,
+            dataset1=list(table1.table_path),
+            dataset2=list(table2.table_path),
+            rows=rows,
+            summary=summary,
+            columns=columns,
+        )
+    )
 
 
-@dataclass
+@attrs.define(frozen=True)
 class JsonExclusiveRowValue:
     """
     Value of a single column in a row
@@ -96,7 +100,7 @@ class JsonExclusiveRowValue:
     value: Any
 
 
-@dataclass
+@attrs.define(frozen=True)
 class JsonDiffRowValue:
     """
     Pair of diffed values for 2 rows with equal PKs
@@ -108,19 +112,19 @@ class JsonDiffRowValue:
     isPK: bool
 
 
-@dataclass
+@attrs.define(frozen=True)
 class Total:
     dataset1: int
     dataset2: int
 
 
-@dataclass
+@attrs.define(frozen=True)
 class ExclusiveRows:
     dataset1: int
     dataset2: int
 
 
-@dataclass
+@attrs.define(frozen=True)
 class Rows:
     total: Total
     exclusive: ExclusiveRows
@@ -128,18 +132,18 @@ class Rows:
     unchanged: int
 
 
-@dataclass
+@attrs.define(frozen=True)
 class Stats:
     diffCounts: Dict[str, int]
 
 
-@dataclass
+@attrs.define(frozen=True)
 class JsonDiffSummary:
     rows: Rows
     stats: Stats
 
 
-@dataclass
+@attrs.define(frozen=True)
 class ExclusiveColumns:
     dataset1: List[str]
     dataset2: List[str]
@@ -172,14 +176,14 @@ KIND_MAPPING: List[Tuple[Type[ColType], ColumnKind]] = [
 ]
 
 
-@dataclass
+@attrs.define(frozen=True)
 class Column:
     name: str
     type: str
     kind: str
 
 
-@dataclass
+@attrs.define(frozen=True)
 class JsonColumnsSummary:
     dataset1: List[Column]
     dataset2: List[Column]
@@ -188,19 +192,19 @@ class JsonColumnsSummary:
     typeChanged: List[str]
 
 
-@dataclass
+@attrs.define(frozen=True)
 class ExclusiveDiff:
     dataset1: List[Dict[str, JsonExclusiveRowValue]]
     dataset2: List[Dict[str, JsonExclusiveRowValue]]
 
 
-@dataclass
+@attrs.define(frozen=True)
 class RowsDiff:
     exclusive: ExclusiveDiff
     diff: List[Dict[str, JsonDiffRowValue]]
 
 
-@dataclass
+@attrs.define(frozen=True)
 class FailedDiff:
     status: str  # Literal ["failed"]
     model: str
@@ -211,7 +215,7 @@ class FailedDiff:
     version: str = "1.0.0"
 
 
-@dataclass
+@attrs.define(frozen=True)
 class JsonDiff:
     status: str  # Literal ["success"]
     result: str  # Literal ["different", "identical"]

--- a/data_diff/info_tree.py
+++ b/data_diff/info_tree.py
@@ -1,12 +1,11 @@
-from dataclasses import field
 from typing import List, Dict, Optional, Any, Tuple, Union
 
-from runtype import dataclass
+import attrs
 
 from data_diff.table_segment import TableSegment
 
 
-@dataclass(frozen=False)
+@attrs.define(frozen=False)
 class SegmentInfo:
     tables: List[TableSegment]
 
@@ -15,7 +14,7 @@ class SegmentInfo:
     is_diff: Optional[bool] = None
     diff_count: Optional[int] = None
 
-    rowcounts: Dict[int, int] = field(default_factory=dict)
+    rowcounts: Dict[int, int] = attrs.field(factory=dict)
     max_rows: Optional[int] = None
 
     def set_diff(self, diff: List[Union[Tuple[Any, ...], List[Any]]], schema: Optional[Tuple[Tuple[str, type]]] = None):
@@ -40,10 +39,10 @@ class SegmentInfo:
         }
 
 
-@dataclass
+@attrs.define(frozen=True)
 class InfoTree:
     info: SegmentInfo
-    children: List["InfoTree"] = field(default_factory=list)
+    children: List["InfoTree"] = attrs.field(factory=list)
 
     def add_node(self, table1: TableSegment, table2: TableSegment, max_rows: int = None):
         node = InfoTree(SegmentInfo([table1, table2], max_rows=max_rows))

--- a/data_diff/info_tree.py
+++ b/data_diff/info_tree.py
@@ -10,13 +10,13 @@ from data_diff.table_segment import TableSegment
 class SegmentInfo:
     tables: List[TableSegment]
 
-    diff: List[Union[Tuple[Any, ...], List[Any]]] = None
-    diff_schema: Tuple[Tuple[str, type], ...] = None
-    is_diff: bool = None
-    diff_count: int = None
+    diff: Optional[List[Union[Tuple[Any, ...], List[Any]]]] = None
+    diff_schema: Optional[Tuple[Tuple[str, type], ...]] = None
+    is_diff: Optional[bool] = None
+    diff_count: Optional[int] = None
 
     rowcounts: Dict[int, int] = field(default_factory=dict)
-    max_rows: int = None
+    max_rows: Optional[int] = None
 
     def set_diff(self, diff: List[Union[Tuple[Any, ...], List[Any]]], schema: Optional[Tuple[Tuple[str, type]]] = None):
         self.diff_schema = schema

--- a/data_diff/joindiff_tables.py
+++ b/data_diff/joindiff_tables.py
@@ -138,7 +138,7 @@ class JoinDiffer(TableDiffer):
 
     validate_unique_key: bool = True
     sample_exclusive_rows: bool = False
-    materialize_to_table: DbPath = None
+    materialize_to_table: Optional[DbPath] = None
     materialize_all_rows: bool = False
     table_write_limit: int = TABLE_WRITE_LIMIT
     skip_null_keys: bool = False

--- a/data_diff/lexicographic_space.py
+++ b/data_diff/lexicographic_space.py
@@ -20,6 +20,9 @@ keys are not evenly distributed.
 from random import randint, randrange
 
 from typing import Tuple
+
+import attrs
+
 from data_diff.utils import safezip
 
 Vector = Tuple[int]
@@ -56,6 +59,7 @@ def irandrange(start, stop):
     return randrange(start, stop)
 
 
+@attrs.define(frozen=True)
 class LexicographicSpace:
     """Lexicographic space of arbitrary dimensions.
 

--- a/data_diff/lexicographic_space.py
+++ b/data_diff/lexicographic_space.py
@@ -63,6 +63,7 @@ class LexicographicSpace:
     """
 
     def __init__(self, dims: Vector):
+        super().__init__()
         self.dims = dims
 
     def __contains__(self, v: Vector):
@@ -120,6 +121,8 @@ class BoundedLexicographicSpace:
     """
 
     def __init__(self, min_bound: Vector, max_bound: Vector):
+        super().__init__()
+
         dims = tuple(mx - mn for mn, mx in safezip(min_bound, max_bound))
         if not all(d >= 0 for d in dims):
             raise ValueError("Error: Negative dimension!")

--- a/data_diff/queries/ast_classes.py
+++ b/data_diff/queries/ast_classes.py
@@ -20,6 +20,7 @@ class QB_TypeError(QueryBuilderError):
     pass
 
 
+@attrs.define(frozen=True)
 class Root:
     "Nodes inheriting from Root can be used as root statements in SQL (e.g. SELECT yes, RANDOM() no)"
 
@@ -82,6 +83,7 @@ def _drop_skips_dict(exprs_dict):
     return {k: v for k, v in exprs_dict.items() if v is not SKIP}
 
 
+@attrs.define(frozen=True)
 class ITable:
     @property
     def source_table(self) -> "ITable":  # not always Self, it can be a substitute
@@ -374,6 +376,7 @@ class UnaryOp(LazyOps, ExprNode):
     expr: Expr
 
 
+@attrs.define(frozen=True)
 class BinBoolOp(BinOp):
     @property
     def type(self) -> Optional[type]:
@@ -689,6 +692,7 @@ class _ResolveColumn(LazyOps, ExprNode):
         return self._get_resolved().name
 
 
+@attrs.define(frozen=True)
 class This:
     """Builder object for accessing table attributes.
 
@@ -741,6 +745,7 @@ class Explain(ExprNode, Root):
         return str
 
 
+@attrs.define(frozen=True)
 class CurrentTimestamp(ExprNode):
     @property
     def type(self) -> Optional[type]:
@@ -759,6 +764,7 @@ class TimeTravel(ITable):  # TODO: Unused?
 # DDL
 
 
+@attrs.define(frozen=True)
 class Statement(Compilable, Root):
     @property
     def type(self) -> Optional[type]:

--- a/data_diff/queries/ast_classes.py
+++ b/data_diff/queries/ast_classes.py
@@ -28,7 +28,9 @@ class Root:
 class ExprNode(Compilable):
     "Base class for query expression nodes"
 
-    type: Any = None
+    @property
+    def type(self) -> Optional[type]:
+        return None
 
     def _dfs_values(self):
         yield self
@@ -216,7 +218,10 @@ class Concat(ExprNode):
 class Count(ExprNode):
     expr: Expr = None
     distinct: bool = False
-    type = int
+
+    @property
+    def type(self) -> Optional[type]:
+        return int
 
 
 class LazyOps:
@@ -337,7 +342,10 @@ class QB_When:
 class IsDistinctFrom(ExprNode, LazyOps):
     a: Expr
     b: Expr
-    type = bool
+
+    @property
+    def type(self) -> Optional[type]:
+        return bool
 
 
 @dataclass(eq=False, order=False)
@@ -361,7 +369,9 @@ class UnaryOp(ExprNode, LazyOps):
 
 
 class BinBoolOp(BinOp):
-    type = bool
+    @property
+    def type(self) -> Optional[type]:
+        return bool
 
 
 @dataclass(eq=False, order=False)
@@ -700,7 +710,10 @@ class This:
 class In(ExprNode):
     expr: Expr
     list: Sequence[Expr]
-    type = bool
+
+    @property
+    def type(self) -> Optional[type]:
+        return bool
 
 
 @dataclass
@@ -711,7 +724,9 @@ class Cast(ExprNode):
 
 @dataclass
 class Random(ExprNode, LazyOps):
-    type = float
+    @property
+    def type(self) -> Optional[type]:
+        return float
 
 
 @dataclass
@@ -722,11 +737,16 @@ class ConstantTable(ExprNode):
 @dataclass
 class Explain(ExprNode, Root):
     select: Select
-    type = str
+
+    @property
+    def type(self) -> Optional[type]:
+        return str
 
 
 class CurrentTimestamp(ExprNode):
-    type = datetime
+    @property
+    def type(self) -> Optional[type]:
+        return datetime
 
 
 @dataclass
@@ -742,7 +762,9 @@ class TimeTravel(ITable):
 
 
 class Statement(Compilable, Root):
-    type = None
+    @property
+    def type(self) -> Optional[type]:
+        return None
 
 
 @dataclass

--- a/data_diff/queries/ast_classes.py
+++ b/data_diff/queries/ast_classes.py
@@ -55,7 +55,7 @@ Expr = Union[ExprNode, str, bool, int, float, datetime, ArithString, None]
 @dataclass
 class Code(ExprNode, Root):
     code: str
-    args: Dict[str, Expr] = None
+    args: Optional[Dict[str, Expr]] = None
 
 
 def _expr_type(e: Expr) -> type:
@@ -216,7 +216,7 @@ class ITable:
 @dataclass
 class Concat(ExprNode):
     exprs: list
-    sep: str = None
+    sep: Optional[str] = None
 
 
 @dataclass
@@ -293,7 +293,7 @@ class WhenThen(ExprNode):
 @dataclass
 class CaseWhen(ExprNode):
     cases: Sequence[WhenThen]
-    else_expr: Expr = None
+    else_expr: Optional[Expr] = None
 
     @property
     def type(self):
@@ -491,9 +491,9 @@ class TableAlias(ExprNode, ITable):
 @dataclass
 class Join(ExprNode, ITable, Root):
     source_tables: Sequence[ITable]
-    op: str = None
-    on_exprs: Sequence[Expr] = None
-    columns: Sequence[Expr] = None
+    op: Optional[str] = None
+    on_exprs: Optional[Sequence[Expr]] = None
+    columns: Optional[Sequence[Expr]] = None
 
     @property
     def schema(self) -> Schema:
@@ -534,9 +534,9 @@ class Join(ExprNode, ITable, Root):
 @dataclass
 class GroupBy(ExprNode, ITable, Root):
     table: ITable
-    keys: Sequence[Expr] = None  # IKey?
-    values: Sequence[Expr] = None
-    having_exprs: Sequence[Expr] = None
+    keys: Optional[Sequence[Expr]] = None  # IKey?
+    values: Optional[Sequence[Expr]] = None
+    having_exprs: Optional[Sequence[Expr]] = None
 
     def __post_init__(self):
         assert self.keys or self.values
@@ -580,15 +580,15 @@ class TableOp(ExprNode, ITable, Root):
 
 @dataclass
 class Select(ExprNode, ITable, Root):
-    table: Expr = None
-    columns: Sequence[Expr] = None
-    where_exprs: Sequence[Expr] = None
-    order_by_exprs: Sequence[Expr] = None
-    group_by_exprs: Sequence[Expr] = None
-    having_exprs: Sequence[Expr] = None
-    limit_expr: int = None
+    table: Optional[Expr] = None
+    columns: Optional[Sequence[Expr]] = None
+    where_exprs: Optional[Sequence[Expr]] = None
+    order_by_exprs: Optional[Sequence[Expr]] = None
+    group_by_exprs: Optional[Sequence[Expr]] = None
+    having_exprs: Optional[Sequence[Expr]] = None
+    limit_expr: Optional[int] = None
     distinct: bool = False
-    optimizer_hints: Sequence[Expr] = None
+    optimizer_hints: Optional[Sequence[Expr]] = None
 
     @property
     def schema(self) -> Schema:
@@ -636,8 +636,8 @@ class Select(ExprNode, ITable, Root):
 @dataclass
 class Cte(ExprNode, ITable):
     table: Expr
-    name: str = None
-    params: Sequence[str] = None
+    name: Optional[str] = None
+    params: Optional[Sequence[str]] = None
 
     @property
     def source_table(self) -> "ITable":
@@ -667,7 +667,7 @@ def resolve_names(source_table, exprs):
 @dataclass(frozen=False, eq=False, order=False)
 class _ResolveColumn(ExprNode, LazyOps):
     resolve_name: str
-    resolved: Expr = None
+    resolved: Optional[Expr] = None
 
     def resolve(self, expr: Expr):
         if self.resolved is not None:
@@ -750,9 +750,9 @@ class CurrentTimestamp(ExprNode):
 class TimeTravel(ITable):
     table: TablePath
     before: bool = False
-    timestamp: datetime = None
-    offset: int = None
-    statement: str = None
+    timestamp: Optional[datetime] = None
+    offset: Optional[int] = None
+    statement: Optional[str] = None
 
 
 # DDL
@@ -767,9 +767,9 @@ class Statement(Compilable, Root):
 @dataclass
 class CreateTable(Statement):
     path: TablePath
-    source_table: Expr = None
+    source_table: Optional[Expr] = None
     if_not_exists: bool = False
-    primary_keys: List[str] = None
+    primary_keys: Optional[List[str]] = None
 
 
 @dataclass
@@ -787,8 +787,8 @@ class TruncateTable(Statement):
 class InsertToTable(Statement):
     path: TablePath
     expr: Expr
-    columns: List[str] = None
-    returning_exprs: List[str] = None
+    columns: Optional[List[str]] = None
+    returning_exprs: Optional[List[str]] = None
 
     def returning(self, *exprs) -> Self:
         """Add a 'RETURNING' clause to the insert expression.

--- a/data_diff/queries/base.py
+++ b/data_diff/queries/base.py
@@ -1,6 +1,9 @@
 from typing import Generator
 
+import attrs
 
+
+@attrs.define(frozen=True)
 class _SKIP:
     def __repr__(self):
         return "SKIP"

--- a/data_diff/queries/extras.py
+++ b/data_diff/queries/extras.py
@@ -10,7 +10,7 @@ from data_diff.queries.ast_classes import Expr, ExprNode
 @dataclass
 class NormalizeAsString(ExprNode):
     expr: ExprNode
-    expr_type: ColType = None
+    expr_type: Optional[ColType] = None
 
     @property
     def type(self) -> Optional[type]:
@@ -20,7 +20,7 @@ class NormalizeAsString(ExprNode):
 @dataclass
 class ApplyFuncAndNormalizeAsString(ExprNode):
     expr: ExprNode
-    apply_func: Callable = None
+    apply_func: Optional[Callable] = None
 
 
 @dataclass

--- a/data_diff/queries/extras.py
+++ b/data_diff/queries/extras.py
@@ -1,13 +1,13 @@
 "Useful AST classes that don't quite fall within the scope of regular SQL"
 from typing import Callable, Optional, Sequence
-from runtype import dataclass
+
+import attrs
 
 from data_diff.abcs.database_types import ColType
-
 from data_diff.queries.ast_classes import Expr, ExprNode
 
 
-@dataclass
+@attrs.define(frozen=True)
 class NormalizeAsString(ExprNode):
     expr: ExprNode
     expr_type: Optional[ColType] = None
@@ -17,12 +17,12 @@ class NormalizeAsString(ExprNode):
         return str
 
 
-@dataclass
+@attrs.define(frozen=True)
 class ApplyFuncAndNormalizeAsString(ExprNode):
     expr: ExprNode
     apply_func: Optional[Callable] = None
 
 
-@dataclass
+@attrs.define(frozen=True)
 class Checksum(ExprNode):
     exprs: Sequence[Expr]

--- a/data_diff/queries/extras.py
+++ b/data_diff/queries/extras.py
@@ -1,5 +1,5 @@
 "Useful AST classes that don't quite fall within the scope of regular SQL"
-from typing import Callable, Sequence
+from typing import Callable, Optional, Sequence
 from runtype import dataclass
 
 from data_diff.abcs.database_types import ColType
@@ -11,7 +11,10 @@ from data_diff.queries.ast_classes import Expr, ExprNode
 class NormalizeAsString(ExprNode):
     expr: ExprNode
     expr_type: ColType = None
-    type = str
+
+    @property
+    def type(self) -> Optional[type]:
+        return str
 
 
 @dataclass

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -112,18 +112,18 @@ class TableSegment:
 
     # Columns
     key_columns: Tuple[str, ...]
-    update_column: str = None
+    update_column: Optional[str] = None
     extra_columns: Tuple[str, ...] = ()
 
     # Restrict the segment
-    min_key: Vector = None
-    max_key: Vector = None
-    min_update: DbTime = None
-    max_update: DbTime = None
-    where: str = None
+    min_key: Optional[Vector] = None
+    max_key: Optional[Vector] = None
+    min_update: Optional[DbTime] = None
+    max_update: Optional[DbTime] = None
+    where: Optional[str] = None
 
-    case_sensitive: bool = True
-    _schema: Schema = None
+    case_sensitive: Optional[bool] = True
+    _schema: Optional[Schema] = None
 
     def __post_init__(self):
         if not self.update_column and (self.min_update or self.max_update):

--- a/data_diff/thread_utils.py
+++ b/data_diff/thread_utils.py
@@ -7,6 +7,8 @@ from concurrent.futures.thread import _WorkItem
 from time import sleep
 from typing import Callable, Iterator, Optional
 
+import attrs
+
 
 class AutoPriorityQueue(PriorityQueue):
     """Overrides PriorityQueue to automatically get the priority from _WorkItem.kwargs
@@ -34,10 +36,10 @@ class PriorityThreadPoolExecutor(ThreadPoolExecutor):
 
     def __init__(self, *args):
         super().__init__(*args)
-
         self._work_queue = AutoPriorityQueue()
 
 
+@attrs.define(frozen=False, init=False)
 class ThreadedYielder(Iterable):
     """Yields results from multiple threads into a single iterator, ordered by priority.
 
@@ -48,6 +50,11 @@ class ThreadedYielder(Iterable):
     _pool: ThreadPoolExecutor
     _futures: deque
     _yield: deque
+    _exception: Optional[None]
+
+    _pool: ThreadPoolExecutor
+    _futures: deque
+    _yield: deque = attrs.field(alias="_yield")  # Python keyword!
     _exception: Optional[None]
 
     def __init__(self, max_workers: Optional[int] = None):

--- a/data_diff/thread_utils.py
+++ b/data_diff/thread_utils.py
@@ -46,6 +46,7 @@ class ThreadedYielder(Iterable):
     """
 
     def __init__(self, max_workers: Optional[int] = None):
+        super().__init__()
         self._pool = PriorityThreadPoolExecutor(max_workers)
         self._futures = deque()
         self._yield = deque()

--- a/data_diff/thread_utils.py
+++ b/data_diff/thread_utils.py
@@ -45,6 +45,11 @@ class ThreadedYielder(Iterable):
     Priority for the iterator can be provided via the keyword argument 'priority'. (higher runs first)
     """
 
+    _pool: ThreadPoolExecutor
+    _futures: deque
+    _yield: deque
+    _exception: Optional[None]
+
     def __init__(self, max_workers: Optional[int] = None):
         super().__init__()
         self._pool = PriorityThreadPoolExecutor(max_workers)

--- a/data_diff/utils.py
+++ b/data_diff/utils.py
@@ -73,6 +73,7 @@ class CaseAwareMapping(MutableMapping[str, V]):
 
 class CaseInsensitiveDict(CaseAwareMapping):
     def __init__(self, initial):
+        super().__init__()
         self._dict = {k.lower(): (k, v) for k, v in dict(initial).items()}
 
     def __getitem__(self, key: str) -> V:
@@ -175,6 +176,8 @@ def alphanums_to_numbers(s1: str, s2: str):
 
 class ArithAlphanumeric(ArithString):
     def __init__(self, s: str, max_len=None):
+        super().__init__()
+
         if s is None:
             raise ValueError("Alphanum string cannot be None")
         if max_len and len(s) > max_len:

--- a/data_diff/utils.py
+++ b/data_diff/utils.py
@@ -11,6 +11,7 @@ import threading
 from datetime import datetime
 from uuid import UUID
 
+import attrs
 from packaging.version import parse as parse_version
 import requests
 from tabulate import tabulate
@@ -115,6 +116,7 @@ class CaseSensitiveDict(dict, CaseAwareMapping):
 alphanums = " -" + string.digits + string.ascii_uppercase + "_" + string.ascii_lowercase
 
 
+@attrs.define(frozen=True)
 class ArithString:
     @classmethod
     def new(cls, *args, **kw) -> Self:
@@ -126,6 +128,7 @@ class ArithString:
         return [self.new(int=i) for i in checkpoints]
 
 
+# @attrs.define  # not as long as it inherits from UUID
 class ArithUUID(UUID, ArithString):
     "A UUID that supports basic arithmetic (add, sub)"
 
@@ -174,24 +177,20 @@ def alphanums_to_numbers(s1: str, s2: str):
     return n1, n2
 
 
+@attrs.define(frozen=True)
 class ArithAlphanumeric(ArithString):
     _str: str
-    _max_len: Optional[int]
+    _max_len: Optional[int] = None
 
-    def __init__(self, s: str, max_len=None):
-        super().__init__()
-
-        if s is None:
+    def __attrs_post_init__(self):
+        if self._str is None:
             raise ValueError("Alphanum string cannot be None")
-        if max_len and len(s) > max_len:
-            raise ValueError(f"Length of alphanum value '{str}' is longer than the expected {max_len}")
+        if self._max_len and len(self._str) > self._max_len:
+            raise ValueError(f"Length of alphanum value '{str}' is longer than the expected {self._max_len}")
 
-        for ch in s:
+        for ch in self._str:
             if ch not in alphanums:
                 raise ValueError(f"Unexpected character {ch} in alphanum string")
-
-        self._str = s
-        self._max_len = max_len
 
     # @property
     # def int(self):

--- a/data_diff/utils.py
+++ b/data_diff/utils.py
@@ -4,7 +4,7 @@ import math
 import re
 import string
 from abc import abstractmethod
-from typing import Any, Dict, Iterable, Iterator, List, MutableMapping, Sequence, TypeVar, Union
+from typing import Any, Dict, Iterable, Iterator, List, MutableMapping, Optional, Sequence, TypeVar, Union
 from urllib.parse import urlparse
 import operator
 import threading
@@ -175,6 +175,9 @@ def alphanums_to_numbers(s1: str, s2: str):
 
 
 class ArithAlphanumeric(ArithString):
+    _str: str
+    _max_len: Optional[int]
+
     def __init__(self, s: str, max_len=None):
         super().__init__()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2030,4 +2030,4 @@ vertica = ["vertica-python"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7.2"
-content-hash = "55cde03a00788572dac6310e7bbf61bd2522d70217056a51608bcfc429440fbf"
+content-hash = "c7da70c19432ca716980f3421182d54d7f5d2e0d8bbd7e20dbaf521c8ef7d0fb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ packages = [{ include = "data_diff" }]
 [tool.poetry.dependencies]
 pydantic = "1.10.12"
 python = "^3.7.2"
-runtype = "^0.2.6"
 dsnparse = "<0.2.0"
 click = "^8.1"
 rich = "*"
@@ -47,6 +46,7 @@ urllib3 = "<2"
 oracledb = {version = "*", optional=true}
 pyodbc = {version="^4.0.39", optional=true}
 typing-extensions = ">=4.0.1"
+attrs = "^23.1.0"
 
 [tool.poetry.dev-dependencies]
 parameterized = "*"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import datetime
 from typing import Callable, List, Tuple
 
+import attrs
 import pytz
 
 from data_diff import connect
@@ -130,8 +131,8 @@ class TestQueries(unittest.TestCase):
         raw_schema = db.query_table_schema(t.path)
         schema = db._process_table_schema(t.path, raw_schema)
         schema = create_schema(db.name, t, schema, case_sensitive=True)
-        t = t.replace(schema=schema)
-        t.schema["created_at"] = t.schema["created_at"].replace(precision=t.schema["created_at"].precision)
+        t = attrs.evolve(t, schema=schema)
+        t.schema["created_at"] = attrs.evolve(t.schema["created_at"], precision=t.schema["created_at"].precision)
 
         tbl = table(name, schema=t.schema)
 

--- a/tests/test_database_types.py
+++ b/tests/test_database_types.py
@@ -367,6 +367,7 @@ class PaginatedTable:
     RECORDS_PER_BATCH = 1000000
 
     def __init__(self, table_path, conn):
+        super().__init__()
         self.table_path = table_path
         self.conn = conn
 
@@ -398,6 +399,7 @@ class DateTimeFaker:
     ]
 
     def __init__(self, max):
+        super().__init__()
         self.max = max
 
     def __iter__(self):
@@ -413,6 +415,7 @@ class IntFaker:
     MANUAL_FAKES = [127, -3, -9, 37, 15, 0]
 
     def __init__(self, max):
+        super().__init__()
         self.max = max
 
     def __iter__(self):
@@ -428,6 +431,7 @@ class BooleanFaker:
     MANUAL_FAKES = [False, True, True, False]
 
     def __init__(self, max):
+        super().__init__()
         self.max = max
 
     def __iter__(self):
@@ -458,6 +462,7 @@ class FloatFaker:
     ]
 
     def __init__(self, max):
+        super().__init__()
         self.max = max
 
     def __iter__(self):
@@ -471,6 +476,7 @@ class FloatFaker:
 
 class UUID_Faker:
     def __init__(self, max):
+        super().__init__()
         self.max = max
 
     def __len__(self):
@@ -486,6 +492,7 @@ class JsonFaker:
     ]
 
     def __init__(self, max):
+        super().__init__()
         self.max = max
 
     def __iter__(self):

--- a/tests/test_diff_tables.py
+++ b/tests/test_diff_tables.py
@@ -3,6 +3,8 @@ from typing import Callable
 import uuid
 import unittest
 
+import attrs
+
 from data_diff.queries.api import table, this, commit, code
 from data_diff.utils import ArithAlphanumeric, numberToAlphanum
 
@@ -382,13 +384,13 @@ class TestUUIDs(DiffTestCase):
         self.assertRaises(ValueError, list, differ.diff_tables(self.a, self.b))
 
     def test_where_sampling(self):
-        a = self.a.replace(where="1=1")
+        a = attrs.evolve(self.a, where="1=1")
 
         differ = HashDiffer(bisection_factor=2)
         diff = list(differ.diff_tables(a, self.b))
         self.assertEqual(diff, [("-", (str(self.new_uuid), "This one is different"))])
 
-        a_empty = self.a.replace(where="1=0")
+        a_empty = attrs.evolve(self.a, where="1=0")
         self.assertRaises(ValueError, list, differ.diff_tables(a_empty, self.b))
 
 
@@ -504,9 +506,9 @@ class TestTableSegment(DiffTestCase):
     def test_table_segment(self):
         early = datetime(2021, 1, 1, 0, 0)
         late = datetime(2022, 1, 1, 0, 0)
-        self.assertRaises(ValueError, self.table.replace, min_update=late, max_update=early)
+        self.assertRaises(ValueError, attrs.evolve, self.table, min_update=late, max_update=early)
 
-        self.assertRaises(ValueError, self.table.replace, min_key=Vector((10,)), max_key=Vector((0,)))
+        self.assertRaises(ValueError, attrs.evolve, self.table, min_key=Vector((10,)), max_key=Vector((0,)))
 
     def test_case_awareness(self):
         src_table = table(self.table_src_path, schema={"id": int, "userid": int, "timestamp": datetime})
@@ -519,11 +521,11 @@ class TestTableSegment(DiffTestCase):
             [src_table.create(), src_table.insert_rows([[1, 9, time_obj], [2, 2, time_obj]], columns=cols), commit]
         )
 
-        res = tuple(self.table.replace(key_columns=("Id",), case_sensitive=False).with_schema().query_key_range())
+        res = tuple(attrs.evolve(self.table, key_columns=("Id",), case_sensitive=False).with_schema().query_key_range())
         self.assertEqual(res, (("1",), ("2",)))
 
         self.assertRaises(
-            KeyError, self.table.replace(key_columns=("Id",), case_sensitive=True).with_schema().query_key_range
+            KeyError, attrs.evolve(self.table, key_columns=("Id",), case_sensitive=True).with_schema().query_key_range
         )
 
 

--- a/tests/test_joindiff.py
+++ b/tests/test_joindiff.py
@@ -1,6 +1,8 @@
 from typing import List
 from datetime import datetime
 
+import attrs
+
 from data_diff.queries.ast_classes import TablePath
 from data_diff.queries.api import table, commit
 from data_diff.table_segment import TableSegment
@@ -114,7 +116,7 @@ class TestJoindiff(DiffTestCase):
 
         # Test materialize
         materialize_path = self.connection.dialect.parse_table_name(f"test_mat_{random_table_suffix()}")
-        mdiffer = self.differ.replace(materialize_to_table=materialize_path)
+        mdiffer = attrs.evolve(self.differ, materialize_to_table=materialize_path)
         diff = list(mdiffer.diff_tables(self.table, self.table2))
         self.assertEqual(expected, diff)
 
@@ -126,7 +128,7 @@ class TestJoindiff(DiffTestCase):
         self.connection.query(t.drop())
 
         # Test materialize all rows
-        mdiffer = mdiffer.replace(materialize_all_rows=True)
+        mdiffer = attrs.evolve(mdiffer, materialize_all_rows=True)
         diff = list(mdiffer.diff_tables(self.table, self.table2))
         self.assertEqual(expected, diff)
         rows = self.connection.query(t.select(), List[tuple])

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,5 +1,7 @@
 import unittest
 
+import attrs
+
 from tests.common import TEST_MYSQL_CONN_STRING
 
 from data_diff.databases import connect
@@ -19,9 +21,8 @@ class TestSQL(unittest.TestCase):
         self.assertEqual("1", self.compiler.compile(1))
 
     def test_compile_table_name(self):
-        self.assertEqual(
-            "`marine_mammals`.`walrus`", self.compiler.replace(root=False).compile(table("marine_mammals", "walrus"))
-        )
+        compiler = attrs.evolve(self.compiler, root=False)
+        self.assertEqual("`marine_mammals`.`walrus`", compiler.compile(table("marine_mammals", "walrus")))
 
     def test_compile_select(self):
         expected_sql = "SELECT name FROM `marine_mammals`.`walrus`"


### PR DESCRIPTION
**A replay of accidentally closed #720.**

**Short-term goal:**  resolve an issue where `runtype` cannot check `isinstance()` check, where the type is a string `"Database"` coming from `Compilar.database: "Database"`. 

Technically, it is a `typing.ForwardRef[]` and must be resolved to actual classes on usage. `attrs` and `pydantic` do that.

There is no way to convert it to a regular class, because there is still a circular class dependency `Database` <> `Compiler`.

---

**Long-term goal:** Since we are moving in the direction of strict type checking, let's make the first step: replace `runtype` with lots of implicit logic and not compatible with MyPy, with `attrs`, which require explicitness and work fine with MyPy & IDEs.

`attrs` is much more beneficial:

* `attrs` is supported by type checkers, such as MyPy & IDEs
* `attrs` is widely used and industry-proven
* `attrs` is explicit in its declarations, there is no magic
* `attrs` has slots

But mainly for the first item — type checking by type checkers.

And since we switch to `attrs` for already dataclass-like types, also expand it to all other (unannotated) classes to ensure proper attribute management in multiple inheritance.

In particular, in the last commit, there are a few cases where the code was ambiguous and had to be resolved by minor remakes.

---

**It is better to review commit-by-commit.**

