### PR TITLE
Call parent's init before field initialisation, not after

### DIFF
--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -176,6 +176,8 @@ class MsSQL(ThreadedDatabase):
     _mssql: Any
 
     def __init__(self, host, port, user, password, *, database, thread_count, **kw):
+        super().__init__(thread_count=thread_count)
+
         args = dict(server=host, port=port, database=database, user=user, password=password, **kw)
         self._args = {k: v for k, v in args.items() if v is not None}
         self._args["driver"] = "{ODBC Driver 18 for SQL Server}"
@@ -190,7 +192,6 @@ class MsSQL(ThreadedDatabase):
             raise ValueError("Specify a default database and schema.")
 
         self._mssql = None
-        super().__init__(thread_count=thread_count)
 
     def create_connection(self):
         self._mssql = import_mssql()


### PR DESCRIPTION
As a rule, `super().__init__()` **MUST**:

* Always be called (never skipped; especially with this complex system of mixins).
* Always be called before anything else is set on the object.

Otherwise, the parent class'es constructor overwrites the properly pre-initialized `self.default_schema` to `None`, and this breaks the table name resolution.