### PR TITLE
Check if `test_metadata` Exists First

### DIFF
--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -483,18 +483,19 @@ class DbtParser:
                     continue
 
                 model_node = manifest.nodes[uid]
-                if node.test_metadata.name == "unique":
-                    column_name: str = node.test_metadata.kwargs["column_name"]
-                    for col in self._parse_concat_pk_definition(column_name):
-                        if model_node is None or col in model_node.columns:
-                            # skip anything that is not a column.
-                            # for example, string literals used in concat
-                            # like "pk1 || '-' || pk2"
-                            cols_by_uid[uid].add(col)
+                if node.test_metadata:
+                    if node.test_metadata.name == "unique":
+                        column_name: str = node.test_metadata.kwargs["column_name"]
+                        for col in self._parse_concat_pk_definition(column_name):
+                            if model_node is None or col in model_node.columns:
+                                # skip anything that is not a column.
+                                # for example, string literals used in concat
+                                # like "pk1 || '-' || pk2"
+                                cols_by_uid[uid].add(col)
 
-                if node.test_metadata.name == "unique_combination_of_columns":
-                    for col in node.test_metadata.kwargs["combination_of_columns"]:
-                        cols_by_uid[uid].add(col)
+                    elif node.test_metadata.name == "unique_combination_of_columns":
+                        for col in node.test_metadata.kwargs["combination_of_columns"]:
+                            cols_by_uid[uid].add(col)
 
             except (KeyError, IndexError, TypeError) as e:
                 logger.warning("Failure while finding unique cols: %s", e)


### PR DESCRIPTION
When running with dbt Cloud artifacts, I came across the error below.

```shell
Running with data-diff=0.9.2
10:28:28 ERROR    'NoneType' object has no attribute 'name'                                                                                                                                                                                                 __main__.py:329
Traceback (most recent call last):
  File "/Users/sung/public-api-demos/venv/bin/data-diff", line 8, in <module>
    sys.exit(main())
  File "/Users/sung/public-api-demos/venv/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/sung/public-api-demos/venv/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/sung/public-api-demos/venv/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/sung/public-api-demos/venv/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/sung/public-api-demos/venv/lib/python3.9/site-packages/data_diff/__main__.py", line 312, in main
    dbt_diff(
  File "/Users/sung/public-api-demos/venv/lib/python3.9/site-packages/data_diff/dbt.py", line 83, in dbt_diff
    dbt_parser = DbtParser(profiles_dir_override, project_dir_override, state)
  File "/Users/sung/public-api-demos/venv/lib/python3.9/site-packages/data_diff/dbt_parser.py", line 138, in __init__
    self.unique_columns = self.get_unique_columns()
  File "/Users/sung/public-api-demos/venv/lib/python3.9/site-packages/data_diff/dbt_parser.py", line 487, in get_unique_columns
    if node.test_metadata.name == "unique":
AttributeError: 'NoneType' object has no attribute 'name'
```

This happens because the `get_unique_columns` function assumes every node has a `test_metadata` attribute which is optional within `dbt_config_validators.py`. This checks the attribute first before proceeding with the rest of the logic. 

