### PR TITLE
Obey the prescribed scale of timestamps in Snowflake

### DIFF
--- a/data_diff/databases/snowflake.py
+++ b/data_diff/databases/snowflake.py
@@ -58,7 +58,8 @@ class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
         else:
             timestamp = f"cast(convert_timezone('UTC', {value}) as timestamp({coltype.precision}))"
 
-        return f"to_char({timestamp}, 'YYYY-MM-DD HH24:MI:SS.FF6')"
+        scale = min(6, coltype.precision)
+        return f"to_char({timestamp}, 'YYYY-MM-DD HH24:MI:SS.FF{scale}')"
 
     def normalize_number(self, value: str, coltype: FractionalType) -> str:
         return self.to_string(f"cast({value} as decimal(38, {coltype.precision}))")


### PR DESCRIPTION
Some databases render timestamps as e.g. `2021-12-31 23:59:59.000` when the scale is set to 3, but Snowflake always renders this as `2021-12-31 23:59:59.000000` regardless of the scale, which leads to differences. This should improve the timestamp comparison.

BUT: Check if it really works with all databases that way. In case it was hard-coded to 6 digits for fractions of seconds everywhere and I missed it.