### PR TITLE
Changed: mssql info_schema_path to UPPERCASE

### DIFF
--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -206,7 +206,7 @@ class MsSQL(ThreadedDatabase):
     def select_table_schema(self, path: DbPath) -> str:
         """Provide SQL for selecting the table schema as (name, type, date_prec, num_prec)"""
         database, schema, name = self._normalize_table_path(path)
-        info_schema_path = ["information_schema", "columns"]
+        info_schema_path = ["INFORMATION_SCHEMA", "COLUMNS"]
         if database:
             info_schema_path.insert(0, self.dialect.quote(database))
 


### PR DESCRIPTION
I have to work with case sensitive mssql instance
and `["information_schema", "columns"]` is not working
while uppercase works.
I think this should also work for case insensitive mssql instances