### PR TITLE
Simplify: Squash database-specialised mixins into their database-specialised dialects

### DIFF
--- a/data_diff/databases/clickhouse.py
+++ b/data_diff/databases/clickhouse.py
@@ -11,7 +11,6 @@ from data_diff.databases.base import (
     ThreadedDatabase,
     import_helper,
     ConnectError,
-    Mixin_RandomSample,
 )
 from data_diff.abcs.database_types import (
     ColType,
@@ -39,75 +38,7 @@ def import_clickhouse():
 
 
 @attrs.define(frozen=False)
-class Mixin_MD5(AbstractMixin_MD5):
-    def md5_as_int(self, s: str) -> str:
-        substr_idx = 1 + MD5_HEXDIGITS - CHECKSUM_HEXDIGITS
-        return (
-            f"reinterpretAsUInt128(reverse(unhex(lowerUTF8(substr(hex(MD5({s})), {substr_idx}))))) - {CHECKSUM_OFFSET}"
-        )
-
-
-@attrs.define(frozen=False)
-class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
-    def normalize_number(self, value: str, coltype: FractionalType) -> str:
-        # If a decimal value has trailing zeros in a fractional part, when casting to string they are dropped.
-        # For example:
-        #   select toString(toDecimal128(1.10, 2));  -- the result is 1.1
-        #   select toString(toDecimal128(1.00, 2)); -- the result is 1
-        # So, we should use some custom approach to save these trailing zeros.
-        # To avoid it, we can add a small value like 0.000001 to prevent dropping of zeros from the end when casting.
-        # For examples above it looks like:
-        #   select toString(toDecimal128(1.10, 2 + 1) + toDecimal128(0.001, 3)); -- the result is 1.101
-        # After that, cut an extra symbol from the string, i.e. 1.101 -> 1.10
-        # So, the algorithm is:
-        # 1. Cast to decimal with precision + 1
-        # 2. Add a small value 10^(-precision-1)
-        # 3. Cast the result to string
-        # 4. Drop the extra digit from the string. To do that, we need to slice the string
-        #    with length = digits in an integer part + 1 (symbol of ".") + precision
-
-        if coltype.precision == 0:
-            return self.to_string(f"round({value})")
-
-        precision = coltype.precision
-        # TODO: too complex, is there better performance way?
-        value = f"""
-            if({value} >= 0, '', '-') || left(
-                toString(
-                    toDecimal128(
-                        round(abs({value}), {precision}),
-                        {precision} + 1
-                    )
-                    +
-                    toDecimal128(
-                        exp10(-{precision + 1}),
-                        {precision} + 1
-                    )
-                ),
-                toUInt8(
-                    greatest(
-                        floor(log10(abs({value}))) + 1,
-                        1
-                    )
-                ) + 1 + {precision}
-            )
-        """
-        return value
-
-    def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
-        prec = coltype.precision
-        if coltype.rounds:
-            timestamp = f"toDateTime64(round(toUnixTimestamp64Micro(toDateTime64({value}, 6)) / 1000000, {prec}), 6)"
-            return self.to_string(timestamp)
-
-        fractional = f"toUnixTimestamp64Micro(toDateTime64({value}, {prec})) % 1000000"
-        fractional = f"lpad({self.to_string(fractional)}, 6, '0')"
-        value = f"formatDateTime({value}, '%Y-%m-%d %H:%M:%S') || '.' || {self.to_string(fractional)}"
-        return f"rpad({value}, {TIMESTAMP_PRECISION_POS + 6}, '0')"
-
-
-@attrs.define(frozen=False)
-class Dialect(BaseDialect, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
+class Dialect(BaseDialect, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "Clickhouse"
     ROUNDS_ON_PREC_LOSS = False
     TYPE_CLASSES = {
@@ -168,6 +99,68 @@ class Dialect(BaseDialect, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, A
 
     def current_timestamp(self) -> str:
         return "now()"
+
+    def md5_as_int(self, s: str) -> str:
+        substr_idx = 1 + MD5_HEXDIGITS - CHECKSUM_HEXDIGITS
+        return (
+            f"reinterpretAsUInt128(reverse(unhex(lowerUTF8(substr(hex(MD5({s})), {substr_idx}))))) - {CHECKSUM_OFFSET}"
+        )
+
+    def normalize_number(self, value: str, coltype: FractionalType) -> str:
+        # If a decimal value has trailing zeros in a fractional part, when casting to string they are dropped.
+        # For example:
+        #   select toString(toDecimal128(1.10, 2));  -- the result is 1.1
+        #   select toString(toDecimal128(1.00, 2)); -- the result is 1
+        # So, we should use some custom approach to save these trailing zeros.
+        # To avoid it, we can add a small value like 0.000001 to prevent dropping of zeros from the end when casting.
+        # For examples above it looks like:
+        #   select toString(toDecimal128(1.10, 2 + 1) + toDecimal128(0.001, 3)); -- the result is 1.101
+        # After that, cut an extra symbol from the string, i.e. 1.101 -> 1.10
+        # So, the algorithm is:
+        # 1. Cast to decimal with precision + 1
+        # 2. Add a small value 10^(-precision-1)
+        # 3. Cast the result to string
+        # 4. Drop the extra digit from the string. To do that, we need to slice the string
+        #    with length = digits in an integer part + 1 (symbol of ".") + precision
+
+        if coltype.precision == 0:
+            return self.to_string(f"round({value})")
+
+        precision = coltype.precision
+        # TODO: too complex, is there better performance way?
+        value = f"""
+            if({value} >= 0, '', '-') || left(
+                toString(
+                    toDecimal128(
+                        round(abs({value}), {precision}),
+                        {precision} + 1
+                    )
+                    +
+                    toDecimal128(
+                        exp10(-{precision + 1}),
+                        {precision} + 1
+                    )
+                ),
+                toUInt8(
+                    greatest(
+                        floor(log10(abs({value}))) + 1,
+                        1
+                    )
+                ) + 1 + {precision}
+            )
+        """
+        return value
+
+    def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
+        prec = coltype.precision
+        if coltype.rounds:
+            timestamp = f"toDateTime64(round(toUnixTimestamp64Micro(toDateTime64({value}, 6)) / 1000000, {prec}), 6)"
+            return self.to_string(timestamp)
+
+        fractional = f"toUnixTimestamp64Micro(toDateTime64({value}, {prec})) % 1000000"
+        fractional = f"lpad({self.to_string(fractional)}, 6, '0')"
+        value = f"formatDateTime({value}, '%Y-%m-%d %H:%M:%S') || '.' || {self.to_string(fractional)}"
+        return f"rpad({value}, {TIMESTAMP_PRECISION_POS + 6}, '0')"
 
 
 @attrs.define(frozen=False, init=False, kw_only=True)

--- a/data_diff/databases/snowflake.py
+++ b/data_diff/databases/snowflake.py
@@ -31,7 +31,6 @@ from data_diff.databases.base import (
     CHECKSUM_MASK,
     ThreadLocalInterpreter,
     CHECKSUM_OFFSET,
-    Mixin_RandomSample,
 )
 
 
@@ -44,74 +43,8 @@ def import_snowflake():
     return snowflake, serialization, default_backend
 
 
-@attrs.define(frozen=False)
-class Mixin_MD5(AbstractMixin_MD5):
-    def md5_as_int(self, s: str) -> str:
-        return f"BITAND(md5_number_lower64({s}), {CHECKSUM_MASK}) - {CHECKSUM_OFFSET}"
-
-
-@attrs.define(frozen=False)
-class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
-    def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
-        if coltype.rounds:
-            timestamp = f"to_timestamp(round(date_part(epoch_nanosecond, convert_timezone('UTC', {value})::timestamp(9))/1000000000, {coltype.precision}))"
-        else:
-            timestamp = f"cast(convert_timezone('UTC', {value}) as timestamp({coltype.precision}))"
-
-        return f"to_char({timestamp}, 'YYYY-MM-DD HH24:MI:SS.FF6')"
-
-    def normalize_number(self, value: str, coltype: FractionalType) -> str:
-        return self.to_string(f"cast({value} as decimal(38, {coltype.precision}))")
-
-    def normalize_boolean(self, value: str, _coltype: Boolean) -> str:
-        return self.to_string(f"{value}::int")
-
-
-@attrs.define(frozen=False)
-class Mixin_Schema(AbstractMixin_Schema):
-    def table_information(self) -> Compilable:
-        return table("INFORMATION_SCHEMA", "TABLES")
-
-    def list_tables(self, table_schema: str, like: Compilable = None) -> Compilable:
-        return (
-            self.table_information()
-            .where(
-                this.TABLE_SCHEMA == table_schema,
-                this.TABLE_NAME.like(like) if like is not None else SKIP,
-                this.TABLE_TYPE == "BASE TABLE",
-            )
-            .select(table_name=this.TABLE_NAME)
-        )
-
-
-class Mixin_TimeTravel(AbstractMixin_TimeTravel):
-    def time_travel(
-        self,
-        table: Compilable,
-        before: bool = False,
-        timestamp: Compilable = None,
-        offset: Compilable = None,
-        statement: Compilable = None,
-    ) -> Compilable:
-        at_or_before = "AT" if before else "BEFORE"
-        if timestamp is not None:
-            assert offset is None and statement is None
-            key = "timestamp"
-            value = timestamp
-        elif offset is not None:
-            assert statement is None
-            key = "offset"
-            value = offset
-        else:
-            assert statement is not None
-            key = "statement"
-            value = statement
-
-        return code(f"{{table}} {at_or_before}({key} => {{value}})", table=table, value=value)
-
-
 class Dialect(
-    BaseDialect, Mixin_Schema, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, AbstractMixin_NormalizeValue
+    BaseDialect, AbstractMixin_Schema, AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_TimeTravel
 ):
     name = "Snowflake"
     ROUNDS_ON_PREC_LOSS = False
@@ -152,6 +85,61 @@ class Dialect(
         if isinstance(t, TimestampTZ):
             return f"timestamp_tz({t.precision})"
         return super().type_repr(t)
+
+    def md5_as_int(self, s: str) -> str:
+        return f"BITAND(md5_number_lower64({s}), {CHECKSUM_MASK}) - {CHECKSUM_OFFSET}"
+
+    def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
+        if coltype.rounds:
+            timestamp = f"to_timestamp(round(date_part(epoch_nanosecond, convert_timezone('UTC', {value})::timestamp(9))/1000000000, {coltype.precision}))"
+        else:
+            timestamp = f"cast(convert_timezone('UTC', {value}) as timestamp({coltype.precision}))"
+
+        return f"to_char({timestamp}, 'YYYY-MM-DD HH24:MI:SS.FF6')"
+
+    def normalize_number(self, value: str, coltype: FractionalType) -> str:
+        return self.to_string(f"cast({value} as decimal(38, {coltype.precision}))")
+
+    def normalize_boolean(self, value: str, _coltype: Boolean) -> str:
+        return self.to_string(f"{value}::int")
+
+    def table_information(self) -> Compilable:
+        return table("INFORMATION_SCHEMA", "TABLES")
+
+    def list_tables(self, table_schema: str, like: Compilable = None) -> Compilable:
+        return (
+            self.table_information()
+            .where(
+                this.TABLE_SCHEMA == table_schema,
+                this.TABLE_NAME.like(like) if like is not None else SKIP,
+                this.TABLE_TYPE == "BASE TABLE",
+            )
+            .select(table_name=this.TABLE_NAME)
+        )
+
+    def time_travel(
+        self,
+        table: Compilable,
+        before: bool = False,
+        timestamp: Compilable = None,
+        offset: Compilable = None,
+        statement: Compilable = None,
+    ) -> Compilable:
+        at_or_before = "AT" if before else "BEFORE"
+        if timestamp is not None:
+            assert offset is None and statement is None
+            key = "timestamp"
+            value = timestamp
+        elif offset is not None:
+            assert statement is None
+            key = "offset"
+            value = offset
+        else:
+            assert statement is not None
+            key = "statement"
+            value = statement
+
+        return code(f"{{table}} {at_or_before}({key} => {{value}})", table=table, value=value)
 
 
 @attrs.define(frozen=False, init=False, kw_only=True)

--- a/data_diff/databases/trino.py
+++ b/data_diff/databases/trino.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import attrs
 
-from data_diff.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
 from data_diff.abcs.database_types import TemporalType, ColType_UUID
 from data_diff.databases import presto
 from data_diff.databases.base import import_helper
@@ -16,11 +15,9 @@ def import_trino():
     return trino
 
 
-Mixin_MD5 = presto.Mixin_MD5
+class Dialect(presto.Dialect):
+    name = "Trino"
 
-
-@attrs.define(frozen=False)
-class Mixin_NormalizeValue(presto.Mixin_NormalizeValue):
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
             s = f"date_format(cast({value} as timestamp({coltype.precision})), '%Y-%m-%d %H:%i:%S.%f')"
@@ -33,10 +30,6 @@ class Mixin_NormalizeValue(presto.Mixin_NormalizeValue):
 
     def normalize_uuid(self, value: str, coltype: ColType_UUID) -> str:
         return f"TRIM({value})"
-
-
-class Dialect(presto.Dialect, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
-    name = "Trino"
 
 
 @attrs.define(frozen=False, init=False, kw_only=True)

--- a/data_diff/databases/vertica.py
+++ b/data_diff/databases/vertica.py
@@ -14,7 +14,6 @@ from data_diff.databases.base import (
     ColType,
     ThreadedDatabase,
     import_helper,
-    Mixin_RandomSample,
 )
 from data_diff.abcs.database_types import (
     Decimal,
@@ -40,52 +39,7 @@ def import_vertica():
     return vertica_python
 
 
-@attrs.define(frozen=False)
-class Mixin_MD5(AbstractMixin_MD5):
-    def md5_as_int(self, s: str) -> str:
-        return f"CAST(HEX_TO_INTEGER(SUBSTRING(MD5({s}), {1 + MD5_HEXDIGITS - CHECKSUM_HEXDIGITS})) AS NUMERIC(38, 0)) - {CHECKSUM_OFFSET}"
-
-
-@attrs.define(frozen=False)
-class Mixin_NormalizeValue(AbstractMixin_NormalizeValue):
-    def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
-        if coltype.rounds:
-            return f"TO_CHAR({value}::TIMESTAMP({coltype.precision}), 'YYYY-MM-DD HH24:MI:SS.US')"
-
-        timestamp6 = f"TO_CHAR({value}::TIMESTAMP(6), 'YYYY-MM-DD HH24:MI:SS.US')"
-        return (
-            f"RPAD(LEFT({timestamp6}, {TIMESTAMP_PRECISION_POS+coltype.precision}), {TIMESTAMP_PRECISION_POS+6}, '0')"
-        )
-
-    def normalize_number(self, value: str, coltype: FractionalType) -> str:
-        return self.to_string(f"CAST({value} AS NUMERIC(38, {coltype.precision}))")
-
-    def normalize_uuid(self, value: str, _coltype: ColType_UUID) -> str:
-        # Trim doesn't work on CHAR type
-        return f"TRIM(CAST({value} AS VARCHAR))"
-
-    def normalize_boolean(self, value: str, _coltype: Boolean) -> str:
-        return self.to_string(f"cast ({value} as int)")
-
-
-class Mixin_Schema(AbstractMixin_Schema):
-    def table_information(self) -> Compilable:
-        return table("v_catalog", "tables")
-
-    def list_tables(self, table_schema: str, like: Compilable = None) -> Compilable:
-        return (
-            self.table_information()
-            .where(
-                this.table_schema == table_schema,
-                this.table_name.like(like) if like is not None else SKIP,
-            )
-            .select(this.table_name)
-        )
-
-
-class Dialect(
-    BaseDialect, Mixin_Schema, Mixin_MD5, Mixin_NormalizeValue, AbstractMixin_MD5, AbstractMixin_NormalizeValue
-):
+class Dialect(BaseDialect, AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_Schema):
     name = "Vertica"
     ROUNDS_ON_PREC_LOSS = True
 
@@ -154,6 +108,41 @@ class Dialect(
 
     def current_timestamp(self) -> str:
         return "current_timestamp(6)"
+
+    def md5_as_int(self, s: str) -> str:
+        return f"CAST(HEX_TO_INTEGER(SUBSTRING(MD5({s}), {1 + MD5_HEXDIGITS - CHECKSUM_HEXDIGITS})) AS NUMERIC(38, 0)) - {CHECKSUM_OFFSET}"
+
+    def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
+        if coltype.rounds:
+            return f"TO_CHAR({value}::TIMESTAMP({coltype.precision}), 'YYYY-MM-DD HH24:MI:SS.US')"
+
+        timestamp6 = f"TO_CHAR({value}::TIMESTAMP(6), 'YYYY-MM-DD HH24:MI:SS.US')"
+        return (
+            f"RPAD(LEFT({timestamp6}, {TIMESTAMP_PRECISION_POS+coltype.precision}), {TIMESTAMP_PRECISION_POS+6}, '0')"
+        )
+
+    def normalize_number(self, value: str, coltype: FractionalType) -> str:
+        return self.to_string(f"CAST({value} AS NUMERIC(38, {coltype.precision}))")
+
+    def normalize_uuid(self, value: str, _coltype: ColType_UUID) -> str:
+        # Trim doesn't work on CHAR type
+        return f"TRIM(CAST({value} AS VARCHAR))"
+
+    def normalize_boolean(self, value: str, _coltype: Boolean) -> str:
+        return self.to_string(f"cast ({value} as int)")
+
+    def table_information(self) -> Compilable:
+        return table("v_catalog", "tables")
+
+    def list_tables(self, table_schema: str, like: Compilable = None) -> Compilable:
+        return (
+            self.table_information()
+            .where(
+                this.table_schema == table_schema,
+                this.table_name.like(like) if like is not None else SKIP,
+            )
+            .select(this.table_name)
+        )
 
 
 @attrs.define(frozen=False, init=False, kw_only=True)


### PR DESCRIPTION
_Little improvements step by step:_

This time, squash the database-specialised mixins into their corresponding database-specialised dialects — since these mixins are not reused anywhere else.

In particular, resolve the Postgres-Redshift & Presto-Trino pairs with double inheritance of the same methods (first, inherited from the parent dialect class; second, inherited from the parent mixins, which are already included in the parent dialect class).

_This PR does NOT touch the "abstract" mixins **yet** — to be made later (they are not currently included in the base Dialect class, so this change will need extra care)._

**Reviewer hints:** There are no changes in the code & logic itself, but only moves of methods up & down between classes. The big green & red diffs are there because of how git & GitHub detect such changes.