### PR TITLE
Simplify: Remove unused code & mixins

### DIFF
--- a/data_diff/abcs/mixins.py
+++ b/data_diff/abcs/mixins.py
@@ -123,25 +123,6 @@ class AbstractMixin_MD5(AbstractMixin):
 
 
 @attrs.define(frozen=False)
-class AbstractMixin_Schema(AbstractMixin):
-    """Methods for querying the database schema
-
-    TODO: Move AbstractDatabase.query_table_schema() and friends over here
-    """
-
-    def table_information(self) -> Compilable:
-        "Query to return a table of schema information about existing tables"
-        raise NotImplementedError()
-
-    @abstractmethod
-    def list_tables(self, table_schema: str, like: Compilable = None) -> Compilable:
-        """Query to select the list of tables in the schema. (query return type: table[str])
-
-        If 'like' is specified, the value is applied to the table name, using the 'like' operator.
-        """
-
-
-@attrs.define(frozen=False)
 class AbstractMixin_OptimizerHints(AbstractMixin):
     @abstractmethod
     def optimizer_hints(self, optimizer_hints: str) -> str:

--- a/data_diff/abcs/mixins.py
+++ b/data_diff/abcs/mixins.py
@@ -142,24 +142,6 @@ class AbstractMixin_Schema(AbstractMixin):
 
 
 @attrs.define(frozen=False)
-class AbstractMixin_RandomSample(AbstractMixin):
-    @abstractmethod
-    def random_sample_n(self, tbl: str, size: int) -> str:
-        """Take a random sample of the given size, i.e. return 'size' amount of rows"""
-
-    @abstractmethod
-    def random_sample_ratio_approx(self, tbl: str, ratio: float) -> str:
-        """Take a random sample of the approximate size determined by the ratio (0..1), where 0 means no rows, and 1 means all rows
-
-        i.e. the actual mount of rows returned may vary by standard deviation.
-        """
-
-    # def random_sample_ratio(self, table: ITable, ratio: float):
-    #     """Take a random sample of the size determined by the ratio (0..1), where 0 means no rows, and 1 means all rows
-    #     """
-
-
-@attrs.define(frozen=False)
 class AbstractMixin_TimeTravel(AbstractMixin):
     @abstractmethod
     def time_travel(

--- a/data_diff/abcs/mixins.py
+++ b/data_diff/abcs/mixins.py
@@ -142,29 +142,6 @@ class AbstractMixin_Schema(AbstractMixin):
 
 
 @attrs.define(frozen=False)
-class AbstractMixin_TimeTravel(AbstractMixin):
-    @abstractmethod
-    def time_travel(
-        self,
-        table: Compilable,
-        before: bool = False,
-        timestamp: Compilable = None,
-        offset: Compilable = None,
-        statement: Compilable = None,
-    ) -> Compilable:
-        """Selects historical data from a table
-
-        Parameters:
-            table - The name of the table whose history we're querying
-            timestamp - A constant timestamp
-            offset - the time 'offset' seconds before now
-            statement - identifier for statement, e.g. query ID
-
-        Must specify exactly one of `timestamp`, `offset` or `statement`.
-        """
-
-
-@attrs.define(frozen=False)
 class AbstractMixin_OptimizerHints(AbstractMixin):
     @abstractmethod
     def optimizer_hints(self, optimizer_hints: str) -> str:

--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -77,7 +77,6 @@ from data_diff.abcs.database_types import (
 from data_diff.abcs.mixins import AbstractMixin_TimeTravel, Compilable
 from data_diff.abcs.mixins import (
     AbstractMixin_Schema,
-    AbstractMixin_RandomSample,
     AbstractMixin_NormalizeValue,
     AbstractMixin_OptimizerHints,
 )
@@ -216,16 +215,6 @@ class Mixin_Schema(AbstractMixin_Schema):
             )
             .select(this.table_name)
         )
-
-
-@attrs.define(frozen=False)
-class Mixin_RandomSample(AbstractMixin_RandomSample):
-    def random_sample_n(self, tbl: ITable, size: int) -> ITable:
-        # TODO use a more efficient algorithm, when the table count is known
-        return tbl.order_by(Random()).limit(size)
-
-    def random_sample_ratio_approx(self, tbl: ITable, ratio: float) -> ITable:
-        return tbl.where(Random() < ratio)
 
 
 @attrs.define(frozen=False)

--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -48,7 +48,6 @@ from data_diff.queries.ast_classes import (
     TableAlias,
     TableOp,
     TablePath,
-    TimeTravel,
     TruncateTable,
     UnaryOp,
     WhenThen,
@@ -74,7 +73,7 @@ from data_diff.abcs.database_types import (
     Boolean,
     JSON,
 )
-from data_diff.abcs.mixins import AbstractMixin_TimeTravel, Compilable
+from data_diff.abcs.mixins import Compilable
 from data_diff.abcs.mixins import (
     AbstractMixin_Schema,
     AbstractMixin_NormalizeValue,
@@ -327,8 +326,6 @@ class BaseDialect(abc.ABC):
             return self.render_explain(c, elem)
         elif isinstance(elem, CurrentTimestamp):
             return self.render_currenttimestamp(c, elem)
-        elif isinstance(elem, TimeTravel):
-            return self.render_timetravel(c, elem)
         elif isinstance(elem, CreateTable):
             return self.render_createtable(c, elem)
         elif isinstance(elem, DropTable):
@@ -604,16 +601,6 @@ class BaseDialect(abc.ABC):
 
     def render_currenttimestamp(self, c: Compiler, elem: CurrentTimestamp) -> str:
         return self.current_timestamp()
-
-    def render_timetravel(self, c: Compiler, elem: TimeTravel) -> str:
-        assert isinstance(c, AbstractMixin_TimeTravel)
-        return self.compile(
-            c,
-            # TODO: why is it c.? why not self? time-trvelling is the dialect's thing, isnt't it?
-            c.time_travel(
-                elem.table, before=elem.before, timestamp=elem.timestamp, offset=elem.offset, statement=elem.statement
-            ),
-        )
 
     def render_createtable(self, c: Compiler, elem: CreateTable) -> str:
         ne = "IF NOT EXISTS " if elem.if_not_exists else ""

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -23,7 +23,6 @@ from data_diff.abcs.database_types import (
 from data_diff.abcs.mixins import (
     AbstractMixin_MD5,
     AbstractMixin_NormalizeValue,
-    AbstractMixin_Schema,
 )
 from data_diff.abcs.compiler import Compilable
 from data_diff.queries.api import this, table, SKIP, code
@@ -62,7 +61,7 @@ def import_bigquery_service_account_impersonation():
 
 
 @attrs.define(frozen=False)
-class Dialect(BaseDialect, AbstractMixin_Schema, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
+class Dialect(BaseDialect, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "BigQuery"
     ROUNDS_ON_PREC_LOSS = False  # Technically BigQuery doesn't allow implicit rounding or truncation
     TYPE_CLASSES = {
@@ -182,17 +181,6 @@ class Dialect(BaseDialect, AbstractMixin_Schema, AbstractMixin_MD5, AbstractMixi
         # So we do the best effort and compare it as strings, hoping that the JSON forms
         # match on both sides: i.e. have properly ordered keys, same spacing, same quotes, etc.
         return f"to_json_string({value})"
-
-    def list_tables(self, table_schema: str, like: Compilable = None) -> Compilable:
-        return (
-            table(table_schema, "INFORMATION_SCHEMA", "TABLES")
-            .where(
-                this.table_schema == table_schema,
-                this.table_name.like(like) if like is not None else SKIP,
-                this.table_type == "BASE TABLE",
-            )
-            .select(this.table_name)
-        )
 
 
 @attrs.define(frozen=False, init=False, kw_only=True)

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -24,7 +24,6 @@ from data_diff.abcs.mixins import (
     AbstractMixin_MD5,
     AbstractMixin_NormalizeValue,
     AbstractMixin_Schema,
-    AbstractMixin_TimeTravel,
 )
 from data_diff.abcs.compiler import Compilable
 from data_diff.queries.api import this, table, SKIP, code
@@ -63,9 +62,7 @@ def import_bigquery_service_account_impersonation():
 
 
 @attrs.define(frozen=False)
-class Dialect(
-    BaseDialect, AbstractMixin_Schema, AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_TimeTravel
-):
+class Dialect(BaseDialect, AbstractMixin_Schema, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "BigQuery"
     ROUNDS_ON_PREC_LOSS = False  # Technically BigQuery doesn't allow implicit rounding or truncation
     TYPE_CLASSES = {
@@ -195,31 +192,6 @@ class Dialect(
                 this.table_type == "BASE TABLE",
             )
             .select(this.table_name)
-        )
-
-    def time_travel(
-        self,
-        table: Compilable,
-        before: bool = False,
-        timestamp: Compilable = None,
-        offset: Compilable = None,
-        statement: Compilable = None,
-    ) -> Compilable:
-        if before:
-            raise NotImplementedError("before=True not supported for BigQuery time-travel")
-
-        if statement is not None:
-            raise NotImplementedError("BigQuery time-travel doesn't support querying by statement id")
-
-        if timestamp is not None:
-            assert offset is None
-            return code("{table} FOR SYSTEM_TIME AS OF {timestamp}", table=table, timestamp=timestamp)
-
-        assert offset is not None
-        return code(
-            "{table} FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {offset} HOUR);",
-            table=table,
-            offset=offset,
         )
 
 

--- a/data_diff/databases/duckdb.py
+++ b/data_diff/databases/duckdb.py
@@ -30,9 +30,7 @@ from data_diff.databases.base import (
     TIMESTAMP_PRECISION_POS,
     CHECKSUM_OFFSET,
 )
-from data_diff.databases.base import MD5_HEXDIGITS, CHECKSUM_HEXDIGITS, Mixin_Schema
-from data_diff.queries.ast_classes import ITable
-from data_diff.queries.api import code
+from data_diff.databases.base import MD5_HEXDIGITS, CHECKSUM_HEXDIGITS
 
 
 @import_helper("duckdb")
@@ -43,7 +41,7 @@ def import_duckdb():
 
 
 @attrs.define(frozen=False)
-class Dialect(BaseDialect, Mixin_Schema, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
+class Dialect(BaseDialect, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "DuckDB"
     ROUNDS_ON_PREC_LOSS = False
     SUPPORTS_PRIMARY_KEY = True

--- a/data_diff/databases/duckdb.py
+++ b/data_diff/databases/duckdb.py
@@ -20,7 +20,6 @@ from data_diff.abcs.database_types import (
 from data_diff.abcs.mixins import (
     AbstractMixin_MD5,
     AbstractMixin_NormalizeValue,
-    AbstractMixin_RandomSample,
 )
 from data_diff.databases.base import (
     Database,
@@ -44,7 +43,7 @@ def import_duckdb():
 
 
 @attrs.define(frozen=False)
-class Dialect(BaseDialect, Mixin_Schema, AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_RandomSample):
+class Dialect(BaseDialect, Mixin_Schema, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "DuckDB"
     ROUNDS_ON_PREC_LOSS = False
     SUPPORTS_PRIMARY_KEY = True
@@ -119,12 +118,6 @@ class Dialect(BaseDialect, Mixin_Schema, AbstractMixin_MD5, AbstractMixin_Normal
 
     def normalize_boolean(self, value: str, _coltype: Boolean) -> str:
         return self.to_string(f"{value}::INTEGER")
-
-    def random_sample_n(self, tbl: ITable, size: int) -> ITable:
-        return code("SELECT * FROM ({tbl}) USING SAMPLE {size};", tbl=tbl, size=size)
-
-    def random_sample_ratio_approx(self, tbl: ITable, ratio: float) -> ITable:
-        return code("SELECT * FROM ({tbl}) USING SAMPLE {percent}%;", tbl=tbl, percent=int(100 * ratio))
 
 
 @attrs.define(frozen=False, init=False, kw_only=True)

--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -13,7 +13,6 @@ from data_diff.databases.base import (
     ConnectError,
     BaseDialect,
 )
-from data_diff.databases.base import Mixin_Schema
 from data_diff.abcs.database_types import (
     JSON,
     NumericType,
@@ -40,7 +39,6 @@ def import_mssql():
 @attrs.define(frozen=False)
 class Dialect(
     BaseDialect,
-    Mixin_Schema,
     Mixin_OptimizerHints,
     AbstractMixin_MD5,
     AbstractMixin_NormalizeValue,

--- a/data_diff/databases/mysql.py
+++ b/data_diff/databases/mysql.py
@@ -31,7 +31,6 @@ from data_diff.databases.base import (
     CHECKSUM_HEXDIGITS,
     TIMESTAMP_PRECISION_POS,
     CHECKSUM_OFFSET,
-    Mixin_Schema,
 )
 
 
@@ -45,7 +44,6 @@ def import_mysql():
 @attrs.define(frozen=False)
 class Dialect(
     BaseDialect,
-    Mixin_Schema,
     Mixin_OptimizerHints,
     AbstractMixin_MD5,
     AbstractMixin_NormalizeValue,

--- a/data_diff/databases/oracle.py
+++ b/data_diff/databases/oracle.py
@@ -16,9 +16,7 @@ from data_diff.abcs.database_types import (
     TimestampTZ,
     FractionalType,
 )
-from data_diff.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_Schema
-from data_diff.abcs.compiler import Compilable
-from data_diff.queries.api import this, table, SKIP
+from data_diff.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
 from data_diff.databases.base import (
     BaseDialect,
     Mixin_OptimizerHints,
@@ -46,7 +44,6 @@ def import_oracle():
 class Dialect(
     BaseDialect,
     Mixin_OptimizerHints,
-    AbstractMixin_Schema,
     AbstractMixin_MD5,
     AbstractMixin_NormalizeValue,
 ):
@@ -161,16 +158,6 @@ class Dialect(
         if coltype.precision:
             format_str += "0." + "9" * (coltype.precision - 1) + "0"
         return f"to_char({value}, '{format_str}')"
-
-    def list_tables(self, table_schema: str, like: Compilable = None) -> Compilable:
-        return (
-            table("ALL_TABLES")
-            .where(
-                this.OWNER == table_schema,
-                this.TABLE_NAME.like(like) if like is not None else SKIP,
-            )
-            .select(table_name=this.TABLE_NAME)
-        )
 
 
 @attrs.define(frozen=False, init=False, kw_only=True)

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -19,7 +19,7 @@ from data_diff.abcs.database_types import (
     Date,
 )
 from data_diff.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
-from data_diff.databases.base import BaseDialect, ThreadedDatabase, import_helper, ConnectError, Mixin_Schema
+from data_diff.databases.base import BaseDialect, ThreadedDatabase, import_helper, ConnectError
 from data_diff.databases.base import (
     MD5_HEXDIGITS,
     CHECKSUM_HEXDIGITS,
@@ -40,7 +40,7 @@ def import_postgresql():
 
 
 @attrs.define(frozen=False)
-class PostgresqlDialect(BaseDialect, Mixin_Schema, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
+class PostgresqlDialect(BaseDialect, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "PostgreSQL"
     ROUNDS_ON_PREC_LOSS = True
     SUPPORTS_PRIMARY_KEY = True

--- a/data_diff/databases/presto.py
+++ b/data_diff/databases/presto.py
@@ -27,7 +27,6 @@ from data_diff.databases.base import (
     Database,
     import_helper,
     ThreadLocalInterpreter,
-    Mixin_Schema,
 )
 from data_diff.databases.base import (
     MD5_HEXDIGITS,
@@ -53,7 +52,7 @@ def import_presto():
     return prestodb
 
 
-class Dialect(BaseDialect, Mixin_Schema, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
+class Dialect(BaseDialect, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "Presto"
     ROUNDS_ON_PREC_LOSS = True
     TYPE_CLASSES = {

--- a/data_diff/databases/snowflake.py
+++ b/data_diff/databases/snowflake.py
@@ -19,7 +19,6 @@ from data_diff.abcs.mixins import (
     AbstractMixin_MD5,
     AbstractMixin_NormalizeValue,
     AbstractMixin_Schema,
-    AbstractMixin_TimeTravel,
 )
 from data_diff.abcs.compiler import Compilable
 from data_diff.queries.api import table, this, SKIP, code
@@ -43,9 +42,7 @@ def import_snowflake():
     return snowflake, serialization, default_backend
 
 
-class Dialect(
-    BaseDialect, AbstractMixin_Schema, AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_TimeTravel
-):
+class Dialect(BaseDialect, AbstractMixin_Schema, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "Snowflake"
     ROUNDS_ON_PREC_LOSS = False
     TYPE_CLASSES = {
@@ -116,30 +113,6 @@ class Dialect(
             )
             .select(table_name=this.TABLE_NAME)
         )
-
-    def time_travel(
-        self,
-        table: Compilable,
-        before: bool = False,
-        timestamp: Compilable = None,
-        offset: Compilable = None,
-        statement: Compilable = None,
-    ) -> Compilable:
-        at_or_before = "AT" if before else "BEFORE"
-        if timestamp is not None:
-            assert offset is None and statement is None
-            key = "timestamp"
-            value = timestamp
-        elif offset is not None:
-            assert statement is None
-            key = "offset"
-            value = offset
-        else:
-            assert statement is not None
-            key = "statement"
-            value = statement
-
-        return code(f"{{table}} {at_or_before}({key} => {{value}})", table=table, value=value)
 
 
 @attrs.define(frozen=False, init=False, kw_only=True)

--- a/data_diff/databases/vertica.py
+++ b/data_diff/databases/vertica.py
@@ -27,9 +27,7 @@ from data_diff.abcs.database_types import (
     Boolean,
     ColType_UUID,
 )
-from data_diff.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_Schema
-from data_diff.abcs.compiler import Compilable
-from data_diff.queries.api import table, this, SKIP
+from data_diff.abcs.mixins import AbstractMixin_MD5, AbstractMixin_NormalizeValue
 
 
 @import_helper("vertica")
@@ -39,7 +37,7 @@ def import_vertica():
     return vertica_python
 
 
-class Dialect(BaseDialect, AbstractMixin_MD5, AbstractMixin_NormalizeValue, AbstractMixin_Schema):
+class Dialect(BaseDialect, AbstractMixin_MD5, AbstractMixin_NormalizeValue):
     name = "Vertica"
     ROUNDS_ON_PREC_LOSS = True
 
@@ -130,19 +128,6 @@ class Dialect(BaseDialect, AbstractMixin_MD5, AbstractMixin_NormalizeValue, Abst
 
     def normalize_boolean(self, value: str, _coltype: Boolean) -> str:
         return self.to_string(f"cast ({value} as int)")
-
-    def table_information(self) -> Compilable:
-        return table("v_catalog", "tables")
-
-    def list_tables(self, table_schema: str, like: Compilable = None) -> Compilable:
-        return (
-            self.table_information()
-            .where(
-                this.table_schema == table_schema,
-                this.table_name.like(like) if like is not None else SKIP,
-            )
-            .select(this.table_name)
-        )
 
 
 @attrs.define(frozen=False, init=False, kw_only=True)

--- a/data_diff/queries/ast_classes.py
+++ b/data_diff/queries/ast_classes.py
@@ -457,26 +457,6 @@ class TablePath(ExprNode, ITable):
             expr = expr.select()
         return InsertToTable(self, expr)
 
-    def time_travel(
-        self, *, before: bool = False, timestamp: datetime = None, offset: int = None, statement: str = None
-    ) -> Compilable:
-        """Selects historical data from the table
-
-        Parameters:
-            before: If false, inclusive of the specified point in time.
-                     If True, only return the time before it. (at/before)
-            timestamp: A constant timestamp
-            offset: the time 'offset' seconds before now
-            statement: identifier for statement, e.g. query ID
-
-        Must specify exactly one of `timestamp`, `offset` or `statement`.
-        """
-        if sum(int(i is not None) for i in (timestamp, offset, statement)) != 1:
-            raise ValueError("Must specify exactly one of `timestamp`, `offset` or `statement`.")
-
-        if timestamp is not None:
-            assert offset is None and statement is None
-
 
 @attrs.define(frozen=True, eq=False)
 class TableAlias(ExprNode, ITable):
@@ -750,15 +730,6 @@ class CurrentTimestamp(ExprNode):
     @property
     def type(self) -> Optional[type]:
         return datetime
-
-
-@attrs.define(frozen=True, eq=False)
-class TimeTravel(ITable):  # TODO: Unused?
-    table: TablePath
-    before: bool = False
-    timestamp: Optional[datetime] = None
-    offset: Optional[int] = None
-    statement: Optional[str] = None
 
 
 # DDL

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -64,44 +64,6 @@ class TestConnect(unittest.TestCase):
 
 
 @test_each_database
-class TestSchema(unittest.TestCase):
-    def test_table_list(self):
-        name = "tbl_" + random_table_suffix()
-        db = get_conn(self.db_cls)
-        tbl = table(db.dialect.parse_table_name(name), schema={"id": int})
-        q = db.dialect.list_tables(db.default_schema, name)
-        assert not db.query(q)
-
-        db.query(tbl.create())
-        self.assertEqual(db.query(q, List[str]), [name])
-
-        db.query(tbl.drop())
-        assert not db.query(q)
-
-    def test_type_mapping(self):
-        name = "tbl_" + random_table_suffix()
-        db = get_conn(self.db_cls)
-        tbl = table(
-            db.dialect.parse_table_name(name),
-            schema={
-                "int": int,
-                "float": float,
-                "datetime": datetime,
-                "str": str,
-                "bool": bool,
-            },
-        )
-        q = db.dialect.list_tables(db.default_schema, name)
-        assert not db.query(q)
-
-        db.query(tbl.create())
-        self.assertEqual(db.query(q, List[str]), [name])
-
-        db.query(tbl.drop())
-        assert not db.query(q)
-
-
-@test_each_database
 class TestQueries(unittest.TestCase):
     def test_current_timestamp(self):
         db = get_conn(self.db_cls)


### PR DESCRIPTION
_Little improvements step by step:_

**Random sampling** & **time traveling** AST nodes, methods and mixins are not used in the codebase at all. We can safely remove them. When and if needed, we will restore and reimplement them.

The **schema fetching** is a bit more complicated: there are 2 schema fetching logics in the code. The one that is actually used is  `Database.select_table_schema()` & `Database.query_table_schema()`. The one in the mixins (`list_tables()` & `table_information()`) is unused. Hence, we can remove it too.

On a matter of whether we want to move the schema fetching from databases to dialects: probably not. Some databases can expose their schemas via non-SQL APIs, such as HTTP API, so it should remain in the database. The dialect should only do the SQL rendering. If we would like to generalize it, we will do this later anew.

_On a side note: The split of Databases & Dialects is also conditional, only for simplicity of testing the SQL rendering without real connection to the database, and vice versa. There would be no much problem in merging the paired classes or their methods if needed._
