### PR TITLE
Prevent type overflow

### DIFF
--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -403,7 +403,8 @@ class BaseDialect(abc.ABC):
     def render_concat(self, c: Compiler, elem: Concat) -> str:
         if self._prevent_overflow_when_concat:
             items = [
-                f"{self.compile(c, Code(self.md5_as_hex(self.to_string(self.compile(c, expr)))))}" for expr in elem.exprs
+                f"{self.compile(c, Code(self.md5_as_hex(self.to_string(self.compile(c, expr)))))}"
+                for expr in elem.exprs
             ]
 
         # We coalesce because on some DBs (e.g. MySQL) concat('a', NULL) is NULL

--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -906,6 +906,8 @@ class Database(abc.ABC):
     Instanciated using :meth:`~data_diff.connect`
     """
 
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = BaseDialect
+
     SUPPORTS_ALPHANUMS: ClassVar[bool] = True
     SUPPORTS_UNIQUE_CONSTAINT: ClassVar[bool] = False
     CONNECT_URI_KWPARAMS: ClassVar[List[str]] = []
@@ -913,6 +915,7 @@ class Database(abc.ABC):
     default_schema: Optional[str] = None
     _interactive: bool = False
     is_closed: bool = False
+    _dialect: BaseDialect = None
 
     @property
     def name(self):
@@ -1141,9 +1144,12 @@ class Database(abc.ABC):
         return super().close()
 
     @property
-    @abstractmethod
     def dialect(self) -> BaseDialect:
         "The dialect of the database. Used internally by Database, and also available publicly."
+
+        if not self._dialect:
+            self._dialect = self.DIALECT_CLASS()
+        return self._dialect
 
     @property
     @abstractmethod

--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -403,7 +403,7 @@ class BaseDialect(abc.ABC):
     def render_concat(self, c: Compiler, elem: Concat) -> str:
         if self._prevent_overflow_when_concat:
             items = [
-                f"{self.compile(c, Code(self.to_md5(self.to_string(self.compile(c, expr)))))}" for expr in elem.exprs
+                f"{self.compile(c, Code(self.md5_as_hex(self.to_string(self.compile(c, expr)))))}" for expr in elem.exprs
             ]
 
         # We coalesce because on some DBs (e.g. MySQL) concat('a', NULL) is NULL
@@ -787,7 +787,7 @@ class BaseDialect(abc.ABC):
         "Provide SQL for computing md5 and returning an int"
 
     @abstractmethod
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         """Method to calculate MD5"""
 
     @abstractmethod

--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -199,12 +199,12 @@ def apply_query(callback: Callable[[str], Any], sql_code: Union[str, ThreadLocal
 class BaseDialect(abc.ABC):
     SUPPORTS_PRIMARY_KEY: ClassVar[bool] = False
     SUPPORTS_INDEXES: ClassVar[bool] = False
+    PREVENT_OVERFLOW_WHEN_CONCAT: ClassVar[bool] = False
     TYPE_CLASSES: ClassVar[Dict[str, Type[ColType]]] = {}
 
     PLACEHOLDER_TABLE = None  # Used for Oracle
 
     # Some database do not support long string so concatenation might lead to type overflow
-    PREVENT_OVERFLOW_WHEN_CONCAT: bool = False
 
     _prevent_overflow_when_concat: bool = False
 

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -134,6 +134,9 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"cast(cast( ('0x' || substr(TO_HEX(md5({s})), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS})) as int64) as numeric) - {CHECKSUM_OFFSET}"
 
+    def to_md5(self, s: str) -> str:
+        return f"md5({s})"
+
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
             timestamp = f"timestamp_micros(cast(round(unix_micros(cast({value} as timestamp))/1000000, {coltype.precision})*1000000 as int))"

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, List, Union
+from typing import Any, ClassVar, List, Union, Type
 
 import attrs
 
@@ -182,9 +182,9 @@ class Dialect(BaseDialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class BigQuery(Database):
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     CONNECT_URI_HELP = "bigquery://<project>/<dataset>"
     CONNECT_URI_PARAMS = ["dataset"]
-    dialect = Dialect()
 
     project: str
     dataset: str

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -134,7 +134,7 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"cast(cast( ('0x' || substr(TO_HEX(md5({s})), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS})) as int64) as numeric) - {CHECKSUM_OFFSET}"
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"md5({s})"
 
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:

--- a/data_diff/databases/clickhouse.py
+++ b/data_diff/databases/clickhouse.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Type
+from typing import Any, ClassVar, Dict, Optional, Type
 
 import attrs
 
@@ -167,7 +167,7 @@ class Dialect(BaseDialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class Clickhouse(ThreadedDatabase):
-    dialect = Dialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     CONNECT_URI_HELP = "clickhouse://<user>:<password>@<host>/<database>"
     CONNECT_URI_PARAMS = ["database?"]
 

--- a/data_diff/databases/clickhouse.py
+++ b/data_diff/databases/clickhouse.py
@@ -105,6 +105,9 @@ class Dialect(BaseDialect):
             f"reinterpretAsUInt128(reverse(unhex(lowerUTF8(substr(hex(MD5({s})), {substr_idx}))))) - {CHECKSUM_OFFSET}"
         )
 
+    def to_md5(self, s: str) -> str:
+        return f"hex(MD5({s}))"
+
     def normalize_number(self, value: str, coltype: FractionalType) -> str:
         # If a decimal value has trailing zeros in a fractional part, when casting to string they are dropped.
         # For example:

--- a/data_diff/databases/clickhouse.py
+++ b/data_diff/databases/clickhouse.py
@@ -105,7 +105,7 @@ class Dialect(BaseDialect):
             f"reinterpretAsUInt128(reverse(unhex(lowerUTF8(substr(hex(MD5({s})), {substr_idx}))))) - {CHECKSUM_OFFSET}"
         )
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"hex(MD5({s}))"
 
     def normalize_number(self, value: str, coltype: FractionalType) -> str:

--- a/data_diff/databases/databricks.py
+++ b/data_diff/databases/databricks.py
@@ -82,7 +82,7 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"cast(conv(substr(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16, 10) as decimal(38, 0)) - {CHECKSUM_OFFSET}"
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"md5({s})"
 
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:

--- a/data_diff/databases/databricks.py
+++ b/data_diff/databases/databricks.py
@@ -82,6 +82,9 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"cast(conv(substr(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16, 10) as decimal(38, 0)) - {CHECKSUM_OFFSET}"
 
+    def to_md5(self, s: str) -> str:
+        return f"md5({s})"
+
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         """Databricks timestamp contains no more than 6 digits in precision"""
 

--- a/data_diff/databases/databricks.py
+++ b/data_diff/databases/databricks.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Dict, Sequence
+from typing import Any, ClassVar, Dict, Sequence, Type
 import logging
 
 import attrs
@@ -107,7 +107,7 @@ class Dialect(BaseDialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class Databricks(ThreadedDatabase):
-    dialect = Dialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     CONNECT_URI_HELP = "databricks://:<access_token>@<server_hostname>/<http_path>"
     CONNECT_URI_PARAMS = ["catalog", "schema"]
 

--- a/data_diff/databases/duckdb.py
+++ b/data_diff/databases/duckdb.py
@@ -100,7 +100,7 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"('0x' || SUBSTRING(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS},{CHECKSUM_HEXDIGITS}))::BIGINT - {CHECKSUM_OFFSET}"
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"md5({s})"
 
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:

--- a/data_diff/databases/duckdb.py
+++ b/data_diff/databases/duckdb.py
@@ -100,6 +100,9 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"('0x' || SUBSTRING(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS},{CHECKSUM_HEXDIGITS}))::BIGINT - {CHECKSUM_OFFSET}"
 
+    def to_md5(self, s: str) -> str:
+        return f"md5({s})"
+
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         # It's precision 6 by default. If precision is less than 6 -> we remove the trailing numbers.
         if coltype.rounds and coltype.precision > 0:

--- a/data_diff/databases/duckdb.py
+++ b/data_diff/databases/duckdb.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union
+from typing import Any, ClassVar, Dict, Union, Type
 
 import attrs
 
@@ -119,7 +119,7 @@ class Dialect(BaseDialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class DuckDB(Database):
-    dialect = Dialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     SUPPORTS_UNIQUE_CONSTAINT = False  # Temporary, until we implement it
     CONNECT_URI_HELP = "duckdb://<dbname>@<filepath>"
     CONNECT_URI_PARAMS = ["database", "dbpath"]

--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, ClassVar, Dict, Optional, Type
 
 import attrs
 
@@ -157,7 +157,7 @@ class Dialect(BaseDialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class MsSQL(ThreadedDatabase):
-    dialect = Dialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     CONNECT_URI_HELP = "mssql://<user>:<password>@<host>/<database>/<schema>"
     CONNECT_URI_PARAMS = ["database", "schema"]
 

--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -151,6 +151,9 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"convert(bigint, convert(varbinary, '0x' + RIGHT(CONVERT(NVARCHAR(32), HashBytes('MD5', {s}), 2), {CHECKSUM_HEXDIGITS}), 1)) - {CHECKSUM_OFFSET}"
 
+    def to_md5(self, s: str) -> str:
+        return f"HashBytes('MD5', {s})"
+
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class MsSQL(ThreadedDatabase):

--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -38,7 +38,7 @@ def import_mssql():
 class Dialect(BaseDialect):
     name = "MsSQL"
     ROUNDS_ON_PREC_LOSS = True
-    SUPPORTS_PRIMARY_KEY = True
+    SUPPORTS_PRIMARY_KEY: ClassVar[bool] = True
     SUPPORTS_INDEXES = True
     TYPE_CLASSES = {
         # Timestamps

--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -151,7 +151,7 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"convert(bigint, convert(varbinary, '0x' + RIGHT(CONVERT(NVARCHAR(32), HashBytes('MD5', {s}), 2), {CHECKSUM_HEXDIGITS}), 1)) - {CHECKSUM_OFFSET}"
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"HashBytes('MD5', {s})"
 
 

--- a/data_diff/databases/mysql.py
+++ b/data_diff/databases/mysql.py
@@ -101,7 +101,7 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"conv(substring(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16, 10) - {CHECKSUM_OFFSET}"
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"md5({s})"
 
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:

--- a/data_diff/databases/mysql.py
+++ b/data_diff/databases/mysql.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, ClassVar, Dict, Type
 
 import attrs
 
@@ -120,7 +120,7 @@ class Dialect(BaseDialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class MySQL(ThreadedDatabase):
-    dialect = Dialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     SUPPORTS_ALPHANUMS = False
     SUPPORTS_UNIQUE_CONSTAINT = True
     CONNECT_URI_HELP = "mysql://<user>:<password>@<host>/<database>"

--- a/data_diff/databases/mysql.py
+++ b/data_diff/databases/mysql.py
@@ -40,7 +40,7 @@ def import_mysql():
 class Dialect(BaseDialect):
     name = "MySQL"
     ROUNDS_ON_PREC_LOSS = True
-    SUPPORTS_PRIMARY_KEY = True
+    SUPPORTS_PRIMARY_KEY: ClassVar[bool] = True
     SUPPORTS_INDEXES = True
     TYPE_CLASSES = {
         # Dates

--- a/data_diff/databases/mysql.py
+++ b/data_diff/databases/mysql.py
@@ -101,6 +101,9 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"conv(substring(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16, 10) - {CHECKSUM_OFFSET}"
 
+    def to_md5(self, s: str) -> str:
+        return f"md5({s})"
+
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
             return self.to_string(f"cast( cast({value} as datetime({coltype.precision})) as datetime(6))")

--- a/data_diff/databases/oracle.py
+++ b/data_diff/databases/oracle.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional, Type
 
 import attrs
 
@@ -164,7 +164,7 @@ class Dialect(
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class Oracle(ThreadedDatabase):
-    dialect = Dialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     CONNECT_URI_HELP = "oracle://<user>:<password>@<host>/<database>"
     CONNECT_URI_PARAMS = ["database?"]
 

--- a/data_diff/databases/oracle.py
+++ b/data_diff/databases/oracle.py
@@ -43,7 +43,7 @@ class Dialect(
     BaseDialect,
 ):
     name = "Oracle"
-    SUPPORTS_PRIMARY_KEY = True
+    SUPPORTS_PRIMARY_KEY: ClassVar[bool] = True
     SUPPORTS_INDEXES = True
     TYPE_CLASSES: Dict[str, type] = {
         "NUMBER": Decimal,

--- a/data_diff/databases/oracle.py
+++ b/data_diff/databases/oracle.py
@@ -137,7 +137,7 @@ class Dialect(
         # TODO: Find a way to use UTL_RAW.CAST_TO_BINARY_INTEGER ?
         return f"to_number(substr(standard_hash({s}, 'MD5'), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 'xxxxxxxxxxxxxxx') - {CHECKSUM_OFFSET}"
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"standard_hash({s}, 'MD5'"
 
     def normalize_uuid(self, value: str, coltype: ColType_UUID) -> str:

--- a/data_diff/databases/oracle.py
+++ b/data_diff/databases/oracle.py
@@ -138,7 +138,7 @@ class Dialect(
         return f"to_number(substr(standard_hash({s}, 'MD5'), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 'xxxxxxxxxxxxxxx') - {CHECKSUM_OFFSET}"
 
     def md5_as_hex(self, s: str) -> str:
-        return f"standard_hash({s}, 'MD5'"
+        return f"standard_hash({s}, 'MD5')"
 
     def normalize_uuid(self, value: str, coltype: ColType_UUID) -> str:
         # Cast is necessary for correct MD5 (trimming not enough)

--- a/data_diff/databases/oracle.py
+++ b/data_diff/databases/oracle.py
@@ -137,6 +137,9 @@ class Dialect(
         # TODO: Find a way to use UTL_RAW.CAST_TO_BINARY_INTEGER ?
         return f"to_number(substr(standard_hash({s}, 'MD5'), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 'xxxxxxxxxxxxxxx') - {CHECKSUM_OFFSET}"
 
+    def to_md5(self, s: str) -> str:
+        return f"standard_hash({s}, 'MD5'"
+
     def normalize_uuid(self, value: str, coltype: ColType_UUID) -> str:
         # Cast is necessary for correct MD5 (trimming not enough)
         return f"CAST(TRIM({value}) AS VARCHAR(36))"

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -98,6 +98,9 @@ class PostgresqlDialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"('x' || substring(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}))::bit({_CHECKSUM_BITSIZE})::bigint - {CHECKSUM_OFFSET}"
 
+    def to_md5(self, s: str) -> str:
+        return f"md5({s})"
+
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
             return f"to_char({value}::timestamp({coltype.precision}), 'YYYY-mm-dd HH24:MI:SS.US')"

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -98,7 +98,7 @@ class PostgresqlDialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"('x' || substring(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}))::bit({_CHECKSUM_BITSIZE})::bigint - {CHECKSUM_OFFSET}"
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"md5({s})"
 
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -42,7 +42,7 @@ def import_postgresql():
 class PostgresqlDialect(BaseDialect):
     name = "PostgreSQL"
     ROUNDS_ON_PREC_LOSS = True
-    SUPPORTS_PRIMARY_KEY = True
+    SUPPORTS_PRIMARY_KEY: ClassVar[bool] = True
     SUPPORTS_INDEXES = True
 
     TYPE_CLASSES: ClassVar[Dict[str, Type[ColType]]] = {

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -122,7 +122,7 @@ class PostgresqlDialect(BaseDialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class PostgreSQL(ThreadedDatabase):
-    dialect = PostgresqlDialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = PostgresqlDialect
     SUPPORTS_UNIQUE_CONSTAINT = True
     CONNECT_URI_HELP = "postgresql://<user>:<password>@<host>/<database>"
     CONNECT_URI_PARAMS = ["database?"]

--- a/data_diff/databases/presto.py
+++ b/data_diff/databases/presto.py
@@ -128,7 +128,7 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"cast(from_base(substr(to_hex(md5(to_utf8({s}))), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16) as decimal(38, 0)) - {CHECKSUM_OFFSET}"
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"to_hex(md5(to_utf8({s})))"
 
     def normalize_uuid(self, value: str, coltype: ColType_UUID) -> str:

--- a/data_diff/databases/presto.py
+++ b/data_diff/databases/presto.py
@@ -128,6 +128,9 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"cast(from_base(substr(to_hex(md5(to_utf8({s}))), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16) as decimal(38, 0)) - {CHECKSUM_OFFSET}"
 
+    def to_md5(self, s: str) -> str:
+        return f"to_hex(md5(to_utf8({s})))"
+
     def normalize_uuid(self, value: str, coltype: ColType_UUID) -> str:
         # Trim doesn't work on CHAR type
         return f"TRIM(CAST({value} AS VARCHAR))"

--- a/data_diff/databases/presto.py
+++ b/data_diff/databases/presto.py
@@ -1,6 +1,6 @@
 from functools import partial
 import re
-from typing import Any
+from typing import Any, ClassVar, Type
 
 import attrs
 
@@ -153,7 +153,7 @@ class Dialect(BaseDialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class Presto(Database):
-    dialect = Dialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     CONNECT_URI_HELP = "presto://<user>@<host>/<catalog>/<schema>"
     CONNECT_URI_PARAMS = ["catalog", "schema"]
 

--- a/data_diff/databases/redshift.py
+++ b/data_diff/databases/redshift.py
@@ -12,6 +12,7 @@ from data_diff.abcs.database_types import (
     TimestampTZ,
 )
 from data_diff.databases.postgresql import (
+    BaseDialect,
     PostgreSQL,
     MD5_HEXDIGITS,
     CHECKSUM_HEXDIGITS,
@@ -79,7 +80,7 @@ class Dialect(PostgresqlDialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class Redshift(PostgreSQL):
-    dialect = Dialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     CONNECT_URI_HELP = "redshift://<user>:<password>@<host>/<database>"
     CONNECT_URI_PARAMS = ["database?"]
 

--- a/data_diff/databases/redshift.py
+++ b/data_diff/databases/redshift.py
@@ -48,7 +48,7 @@ class Dialect(PostgresqlDialect):
     def md5_as_int(self, s: str) -> str:
         return f"strtol(substring(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16)::decimal(38) - {CHECKSUM_OFFSET}"
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"md5({s})"
 
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:

--- a/data_diff/databases/redshift.py
+++ b/data_diff/databases/redshift.py
@@ -47,6 +47,9 @@ class Dialect(PostgresqlDialect):
     def md5_as_int(self, s: str) -> str:
         return f"strtol(substring(md5({s}), {1+MD5_HEXDIGITS-CHECKSUM_HEXDIGITS}), 16)::decimal(38) - {CHECKSUM_OFFSET}"
 
+    def to_md5(self, s: str) -> str:
+        return f"md5({s})"
+
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
             timestamp = f"{value}::timestamp(6)"

--- a/data_diff/databases/snowflake.py
+++ b/data_diff/databases/snowflake.py
@@ -77,7 +77,7 @@ class Dialect(BaseDialect):
         return f"BITAND(md5_number_lower64({s}), {CHECKSUM_MASK}) - {CHECKSUM_OFFSET}"
 
     def md5_as_hex(self, s: str) -> str:
-        return f"md5_number_lower64({s})"
+        return f"md5({s})"
 
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:

--- a/data_diff/databases/snowflake.py
+++ b/data_diff/databases/snowflake.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, List
+from typing import Any, ClassVar, Union, List, Type
 import logging
 
 import attrs
@@ -96,7 +96,7 @@ class Dialect(BaseDialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class Snowflake(Database):
-    dialect = Dialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     CONNECT_URI_HELP = "snowflake://<user>:<password>@<account>/<database>/<SCHEMA>?warehouse=<WAREHOUSE>"
     CONNECT_URI_PARAMS = ["database", "schema"]
     CONNECT_URI_KWPARAMS = ["warehouse"]

--- a/data_diff/databases/snowflake.py
+++ b/data_diff/databases/snowflake.py
@@ -76,6 +76,9 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"BITAND(md5_number_lower64({s}), {CHECKSUM_MASK}) - {CHECKSUM_OFFSET}"
 
+    def to_md5(self, s: str) -> str:
+        return f"md5_number_lower64({s})"
+
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:
             timestamp = f"to_timestamp(round(date_part(epoch_nanosecond, convert_timezone('UTC', {value})::timestamp(9))/1000000000, {coltype.precision}))"

--- a/data_diff/databases/snowflake.py
+++ b/data_diff/databases/snowflake.py
@@ -76,7 +76,7 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"BITAND(md5_number_lower64({s}), {CHECKSUM_MASK}) - {CHECKSUM_OFFSET}"
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"md5_number_lower64({s})"
 
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:

--- a/data_diff/databases/trino.py
+++ b/data_diff/databases/trino.py
@@ -1,11 +1,11 @@
-from typing import Any
+from typing import Any, ClassVar, Type
 
 import attrs
 
 from data_diff.abcs.database_types import TemporalType, ColType_UUID
 from data_diff.databases import presto
 from data_diff.databases.base import import_helper
-from data_diff.databases.base import TIMESTAMP_PRECISION_POS
+from data_diff.databases.base import TIMESTAMP_PRECISION_POS, BaseDialect
 
 
 @import_helper("trino")
@@ -34,7 +34,7 @@ class Dialect(presto.Dialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class Trino(presto.Presto):
-    dialect = Dialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     CONNECT_URI_HELP = "trino://<user>@<host>/<catalog>/<schema>"
     CONNECT_URI_PARAMS = ["catalog", "schema"]
 

--- a/data_diff/databases/vertica.py
+++ b/data_diff/databases/vertica.py
@@ -110,7 +110,7 @@ class Dialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         return f"CAST(HEX_TO_INTEGER(SUBSTRING(MD5({s}), {1 + MD5_HEXDIGITS - CHECKSUM_HEXDIGITS})) AS NUMERIC(38, 0)) - {CHECKSUM_OFFSET}"
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         return f"MD5({s})"
 
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:

--- a/data_diff/databases/vertica.py
+++ b/data_diff/databases/vertica.py
@@ -36,6 +36,7 @@ def import_vertica():
     return vertica_python
 
 
+@attrs.define(frozen=False)
 class Dialect(BaseDialect):
     name = "Vertica"
     ROUNDS_ON_PREC_LOSS = True
@@ -108,6 +109,9 @@ class Dialect(BaseDialect):
 
     def md5_as_int(self, s: str) -> str:
         return f"CAST(HEX_TO_INTEGER(SUBSTRING(MD5({s}), {1 + MD5_HEXDIGITS - CHECKSUM_HEXDIGITS})) AS NUMERIC(38, 0)) - {CHECKSUM_OFFSET}"
+
+    def to_md5(self, s: str) -> str:
+        return f"MD5({s})"
 
     def normalize_timestamp(self, value: str, coltype: TemporalType) -> str:
         if coltype.rounds:

--- a/data_diff/databases/vertica.py
+++ b/data_diff/databases/vertica.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, ClassVar, Dict, List, Type
 
 import attrs
 
@@ -135,7 +135,7 @@ class Dialect(BaseDialect):
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class Vertica(ThreadedDatabase):
-    dialect = Dialect()
+    DIALECT_CLASS: ClassVar[Type[BaseDialect]] = Dialect
     CONNECT_URI_HELP = "vertica://<user>:<password>@<host>/<database>"
     CONNECT_URI_PARAMS = ["database?"]
 

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -208,6 +208,10 @@ class TableDiffer(ThreadBase, ABC):
             event_json = create_start_event_json(options)
             run_as_daemon(send_event_json, event_json)
 
+        if table1.database.dialect.PREVENT_OVERFLOW_WHEN_CONCAT or table2.database.dialect.PREVENT_OVERFLOW_WHEN_CONCAT:
+            table1.database.dialect.enable_preventing_type_overflow()
+            table2.database.dialect.enable_preventing_type_overflow()
+
         start = time.monotonic()
         error = None
         try:

--- a/tests/test_joindiff.py
+++ b/tests/test_joindiff.py
@@ -270,7 +270,9 @@ class TestJoindiff(DiffTestCase):
         self.assertRaises(ValueError, list, x)
 
 
-@test_each_database_in_list(d for d in TEST_DATABASES if d.dialect.SUPPORTS_PRIMARY_KEY and d.SUPPORTS_UNIQUE_CONSTAINT)
+@test_each_database_in_list(
+    d for d in TEST_DATABASES if d.DIALECT_CLASS.SUPPORTS_PRIMARY_KEY and d.SUPPORTS_UNIQUE_CONSTAINT
+)
 class TestUniqueConstraint(DiffTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -76,7 +76,7 @@ class MockDialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         raise NotImplementedError
 
-    def to_md5(self, s: str) -> str:
+    def md5_as_hex(self, s: str) -> str:
         raise NotImplementedError
 
     def normalize_number(self, value: str, coltype: FractionalType) -> str:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -76,6 +76,9 @@ class MockDialect(BaseDialect):
     def md5_as_int(self, s: str) -> str:
         raise NotImplementedError
 
+    def to_md5(self, s: str) -> str:
+        raise NotImplementedError
+
     def normalize_number(self, value: str, coltype: FractionalType) -> str:
         raise NotImplementedError
 


### PR DESCRIPTION
Some databases, for example, Teradata, have a short limit for string and requires to set a number of symbols in `CHAR/VARCHAR`, i.e. it is required to write it like this
```
CREATE TABLE MyTable (
    col_name VARCHAR(n)
)
```
where `n` must be set and has some max allowed value.

To calculate md5 hash and convert it to an integer value, values of columns for one row are cast to strings, and concatenated afterwards. Let me clarify on an example:
```
CREATE TABLE MyTable (
    id INTEGER,
    data VARCHAR(n)
)
```
To concatenate we use a construction like this:
```
CAST(id AS VARCHAR(n1)) || '|'  || CAST(data AS VARCHAR(n2)) 
``` 
The question is what should `n1` and `n2` be? I am sure that the maximum allowed value for a specific type, for example, `N`. It is needed to keep all customer information without losses. However, such a concatenation will lead to a type overflow, because we are trying to have `VARCHAR(N + N)` which is not allowed.

To avoid such an overflow, we should shorten string values but not to loss information. I see one possible solution: taking hash for each item of a concat op, i.e.
```
md5( CAST(id AS VARCHAR(n1)) ) || '|'  || md5( CAST(data AS VARCHAR(n2)) )
``` 

Benefits:
- It is possible to avoid data type overflow for most of cases

Drawbacks:
- Performance might be decreased because we need to calculate hashes quite intensively. However, the current implementation enables it if necessarily i.e. only if at least one of databases participating in cross-diffing has a problem with a fixed varchar. This behavior is controlled by a `PREVENT_OVERFLOW_WHEN_CONCAT` flag.
- Probability of collision increases but i do not think dramatically.
- We still may have data overflow if where are many columns and a max `n` of `VARCHAR(n)` is low. Do not think it is a big problem because typically a large `N` might be 32000 or more symbols so customer columns should have more than 1000 column in diffing.