### PR TITLE
Databricks diff table without segmentation

### DIFF
--- a/data_diff/joindiff_tables.py
+++ b/data_diff/joindiff_tables.py
@@ -9,7 +9,7 @@ from itertools import chain
 
 import attrs
 
-from data_diff.databases import Database, MsSQL, MySQL, BigQuery, Presto, Oracle, Snowflake, DuckDB
+from data_diff.databases import Database, MsSQL, MySQL, BigQuery, Presto, Oracle, Snowflake, DuckDB, Databricks
 from data_diff.abcs.database_types import NumericType, DbPath
 from data_diff.databases.base import Compiler
 from data_diff.queries.api import (
@@ -157,7 +157,7 @@ class JoinDiffer(TableDiffer):
             drop_table(db, self.materialize_to_table)
 
         with self._run_in_background(*bg_funcs):
-            if isinstance(db, (Snowflake, BigQuery, DuckDB)):
+            if isinstance(db, (Snowflake, BigQuery, DuckDB, Databricks)):
                 # Don't segment the table; let the database handling parallelization
                 yield from self._diff_segments(None, table1, table2, info_tree, None)
             else:


### PR DESCRIPTION
The current way of doing the diff with Databricks is quite slow because it is doing the segmentation and is running a lot of queries.
I changed it by adding Databricks to the list of database for which the diff is run without segmentation.