### PR TITLE
Chiel fix link readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ benchmark_*.png
 
 # VSCode
 .vscode
+
+# History
+.history

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ More information about the algorithm and performance considerations can be found
 # Get started
 
 ## Validating dbt model changes between dev and prod
-⚡ Looking to use `data-diff` in dbt development? Head over to [our `data-diff` + `dbt` documentation](https://docs.datafold.com/development_testing/open_source/) to get started!
+⚡ Looking to use `data-diff` in dbt development? Head over to [our `data-diff` + `dbt` documentation](https://docs.datafold.com/development_testing/how_it_works) to get started!
 
 ## Compare data tables between databases
 🔀 To compare data between databases, install `data-diff` with specific database adapters, e.g.:


### PR DESCRIPTION
The current link (re)directs to:
<img width="1920" alt="image" src="https://github.com/datafold/data-diff/assets/22294606/dca86a90-6c11-4470-94df-7bc99ec48247">

But more logical is to go to:
<img width="1920" alt="image" src="https://github.com/datafold/data-diff/assets/22294606/f0939381-b822-40a2-928b-b08ed432ad1c">

