### PR TITLE
databricks does not require "database"

### DIFF
--- a/data_diff/dbt_config_validators.py
+++ b/data_diff/dbt_config_validators.py
@@ -31,7 +31,7 @@ class ManifestJsonConfig(BaseModel):
         resource_type: str
         name: str
         alias: str
-        database: str
+        database: Optional[str]
         schema_: str = Field(..., alias="schema")
         columns: Optional[Dict[str, Column]]
         meta: Dict[str, Any]


### PR DESCRIPTION
this causes validation errors

e.g.
```
nodes -> test.test_name.dbt_utils_unique_combination_of_columns-> database
  none is not an allowed value (type=type_error.none.not_allowed)
```
