### PR TITLE
Resolve failing mssql tests

### DIFF
--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -69,7 +69,7 @@ class Dialect(BaseDialect):
         "varbinary": Text,
         "xml": Text,
         # UUID
-        "uniqueidentifier": Native_UUID,
+        # "uniqueidentifier": Native_UUID,  # It is not supported yet
         # Bool
         "bit": Boolean,
         # JSON
@@ -167,7 +167,7 @@ class Dialect(BaseDialect):
         return f"HashBytes('MD5', {s})"
 
     def normalize_uuid(self, value: str, coltype) -> str:
-        return f"CONVERT(VARCHAR(36), UPPER(TRIM(CONVERT(varchar(4000), {value}))))"
+        return f"CONVERT(VARCHAR(36), TRIM(CONVERT(varchar(4000), {value})))"
 
 
 @attrs.define(frozen=False, init=False, kw_only=True)

--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -94,13 +94,17 @@ class Dialect(BaseDialect):
         WHERE name = CURRENT_USER"""
 
     def to_string(self, s: str):
-        return f"CONVERT(varchar, {s})"
+        return f"CONVERT(varchar(4000), {s})"
 
     def type_repr(self, t) -> str:
         try:
             return {bool: "bit", str: "text"}[t]
         except KeyError:
             return super().type_repr(t)
+
+    def _convert_db_precision_to_digits(self, p: int) -> int:
+        # Subtracting 2 due to wierd precision issues in PostgreSQL
+        return super()._convert_db_precision_to_digits(p) - 2
 
     def random(self) -> str:
         return "rand()"

--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -154,10 +154,7 @@ class Dialect(BaseDialect):
         return formatted_value
 
     def normalize_number(self, value: str, coltype: NumericType) -> str:
-        if coltype.precision == 0:
-            return f"CAST(FLOOR({value}) AS VARCHAR)"
-
-        return f"FORMAT({value}, 'N{coltype.precision}')"
+        return f"FORMAT(CAST({value} AS DECIMAL(38, {coltype.precision})), 'N{coltype.precision}')"
 
     def md5_as_int(self, s: str) -> str:
         return f"convert(bigint, convert(varbinary, '0x' + RIGHT(CONVERT(NVARCHAR(32), HashBytes('MD5', {s}), 2), {CHECKSUM_HEXDIGITS}), 1)) - {CHECKSUM_OFFSET}"

--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -166,6 +166,9 @@ class Dialect(BaseDialect):
     def md5_as_hex(self, s: str) -> str:
         return f"HashBytes('MD5', {s})"
 
+    def normalize_uuid(self, value: str, coltype) -> str:
+        return f"CONVERT(VARCHAR(36), UPPER(TRIM(CONVERT(varchar(4000), {value}))))"
+
 
 @attrs.define(frozen=False, init=False, kw_only=True)
 class MsSQL(ThreadedDatabase):

--- a/tests/test_database_types.py
+++ b/tests/test_database_types.py
@@ -353,7 +353,7 @@ DATABASE_TYPES = {
         "int": ["INT", "BIGINT"],
         "datetime": ["datetime2(6)"],
         "float": ["DECIMAL(6, 2)", "FLOAT", "REAL"],
-        "uuid": ["VARCHAR(100)", "CHAR(100)", "UNIQUEIDENTIFIER"],
+        "uuid": ["VARCHAR(100)", "CHAR(100)"],
         "boolean": [
             "BIT",
         ],


### PR DESCRIPTION
This PR affects MSSQL connector
- Fix timestamp normalization
- Fix number normalization
- Partly fix uuid normalization: text UUID are supported, native UUID is turned of

The reason why i decided to exclude native UUID type from the current implementation is casting.
MSSQL UUID values are stored in upper case, whereas other databases generally use lower case. Moreover, when casting MSSQL UUIDs to python UUIDs, we lose upper case, and it leads to incorrect sql query gereration. 
For example, we want to compare MSSQL vs PostgreSQL tables with UUID primary keys. For MSSQL a query which calculates md5 hash looks like:
```
SELECT 
    COUNT(*), 
    MD5(... [col] ...) 
FROM UUID_TABLE 
WHERE ([col] >= 'af8ef74d-9b83-11ee-8e2a-000000000000') AND ([col] < 'af8efd8d-f0d8-6743-ef3c-000000000011')
```
UUID values in `WHERE` clause are in lower case after query building, whereas we need upper case for them, and as the result, we have an empty sample in contrast to PostgreSQL.

I have not managed to fix this on the MSSQL connection sidbe, it should be done in the core side.