### PR TITLE
Fix precision recognition

### DIFF
--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -201,6 +201,7 @@ class BaseDialect(abc.ABC):
     SUPPORTS_INDEXES: ClassVar[bool] = False
     PREVENT_OVERFLOW_WHEN_CONCAT: ClassVar[bool] = False
     TYPE_CLASSES: ClassVar[Dict[str, Type[ColType]]] = {}
+    DEFAULT_NUMERIC_PRECISION: ClassVar[int] = 0  # effective precision when type is just "NUMERIC"
 
     PLACEHOLDER_TABLE = None  # Used for Oracle
 

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -75,6 +75,9 @@ class Dialect(BaseDialect):
     }
     TYPE_ARRAY_RE = re.compile(r"ARRAY<(.+)>")
     TYPE_STRUCT_RE = re.compile(r"STRUCT<(.+)>")
+    # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#parameterized_decimal_type
+    # The default scale is 9, which means a number can have up to 9 digits after the decimal point.
+    DEFAULT_NUMERIC_PRECISION = 9
 
     def random(self) -> str:
         return "RAND()"

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -76,7 +76,7 @@ class Dialect(BaseDialect):
     TYPE_ARRAY_RE = re.compile(r"ARRAY<(.+)>")
     TYPE_STRUCT_RE = re.compile(r"STRUCT<(.+)>")
     # [BIG]NUMERIC, [BIG]NUMERIC(precision, scale), [BIG]NUMERIC(precision)
-    TYPE_NUMERIC_RE = re.compile(r'^((BIG)?NUMERIC)(?:\((\d+)(?:, (\d+))?\))?$')
+    TYPE_NUMERIC_RE = re.compile(r"^((BIG)?NUMERIC)(?:\((\d+)(?:, (\d+))?\))?$")
     # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#parameterized_decimal_type
     # The default scale is 9, which means a number can have up to 9 digits after the decimal point.
     DEFAULT_NUMERIC_PRECISION = 9
@@ -128,9 +128,7 @@ class Dialect(BaseDialect):
         if m:
             precision = int(m.group(3)) if m.group(3) else None
             scale = int(m.group(4)) if m.group(4) else None
-            col_type = Decimal(
-                precision=scale if scale else 0 if precision else 9
-            )
+            col_type = Decimal(precision=scale if scale else 0 if precision else 9)
             return col_type
 
         return col_type

--- a/data_diff/databases/bigquery.py
+++ b/data_diff/databases/bigquery.py
@@ -123,17 +123,17 @@ class Dialect(BaseDialect):
         if m:
             precision = int(m.group(3)) if m.group(3) else None
             scale = int(m.group(4)) if m.group(4) else None
-            
+
             if scale is not None:
-              # NUMERIC(..., scale) — scale is set explicitly
-              effective_precision = scale
+                # NUMERIC(..., scale) — scale is set explicitly
+                effective_precision = scale
             elif precision is not None:
-              # NUMERIC(...) — scale is missing but precision is set
-              # effectively the same as NUMERIC(..., 0)
-              effective_precision = 0
+                # NUMERIC(...) — scale is missing but precision is set
+                # effectively the same as NUMERIC(..., 0)
+                effective_precision = 0
             else:
-              # NUMERIC → default scale is 9
-              effective_precision = 9
+                # NUMERIC → default scale is 9
+                effective_precision = 9
             col_type = Decimal(precision=effective_precision)
             return col_type
 

--- a/data_diff/databases/duckdb.py
+++ b/data_diff/databases/duckdb.py
@@ -45,6 +45,10 @@ class Dialect(BaseDialect):
     SUPPORTS_PRIMARY_KEY = True
     SUPPORTS_INDEXES = True
 
+    # https://duckdb.org/docs/sql/data_types/numeric#fixed-point-decimals
+    # The default WIDTH and SCALE is DECIMAL(18, 3), if none are specified.
+    DEFAULT_NUMERIC_PRECISION = 3
+
     TYPE_CLASSES = {
         # Timestamps
         "TIMESTAMP WITH TIME ZONE": TimestampTZ,

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -190,21 +190,23 @@ class PostgreSQL(ThreadedDatabase):
         if database:
             info_schema_path.insert(0, database)
 
-        return f"""
-            SELECT column_name, data_type, datetime_precision,
-                CASE
-                    WHEN data_type = 'numeric'
-                        THEN coalesce(numeric_precision, 131072 + 16383)
-                    ELSE numeric_precision
-                END AS numeric_precision,
-                CASE
-                    WHEN data_type = 'numeric'
-                        THEN coalesce(numeric_scale, 16383)
-                    ELSE numeric_scale
-                END AS numeric_scale
-                FROM {'.'.join(info_schema_path)}
-            WHERE table_name = '{table}' AND table_schema = '{schema}'
+        return (
+            f"""SELECT column_name, data_type, datetime_precision,
+                    -- see comment for DEFAULT_NUMERIC_PRECISION
+                    CASE
+                        WHEN data_type = 'numeric'
+                            THEN coalesce(numeric_precision, 131072 + {self.dialect.DEFAULT_NUMERIC_PRECISION})
+                        ELSE numeric_precision
+                    END AS numeric_precision,
+                    CASE
+                        WHEN data_type = 'numeric'
+                            THEN coalesce(numeric_scale, {self.dialect.DEFAULT_NUMERIC_PRECISION})
+                        ELSE numeric_scale
+                    END AS numeric_scale
+                    FROM {'.'.join(info_schema_path)}
+                    WHERE table_name = '{table}' AND table_schema = '{schema}'
             """
+        )
 
     def select_table_unique_columns(self, path: DbPath) -> str:
         database, schema, table = self._normalize_table_path(path)

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -190,8 +190,7 @@ class PostgreSQL(ThreadedDatabase):
         if database:
             info_schema_path.insert(0, database)
 
-        return (
-            f"""
+        return f"""
             SELECT column_name, data_type, datetime_precision,
                 CASE
                     WHEN data_type = 'numeric'
@@ -206,7 +205,6 @@ class PostgreSQL(ThreadedDatabase):
                 FROM {'.'.join(info_schema_path)}
             WHERE table_name = '{table}' AND table_schema = '{schema}'
             """
-        )
 
     def select_table_unique_columns(self, path: DbPath) -> str:
         database, schema, table = self._normalize_table_path(path)

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -190,8 +190,7 @@ class PostgreSQL(ThreadedDatabase):
         if database:
             info_schema_path.insert(0, database)
 
-        return (
-            f"""SELECT column_name, data_type, datetime_precision,
+        return f"""SELECT column_name, data_type, datetime_precision,
                     -- see comment for DEFAULT_NUMERIC_PRECISION
                     CASE
                         WHEN data_type = 'numeric'
@@ -206,7 +205,6 @@ class PostgreSQL(ThreadedDatabase):
                     FROM {'.'.join(info_schema_path)}
                     WHERE table_name = '{table}' AND table_schema = '{schema}'
             """
-        )
 
     def select_table_unique_columns(self, path: DbPath) -> str:
         database, schema, table = self._normalize_table_path(path)

--- a/data_diff/databases/postgresql.py
+++ b/data_diff/databases/postgresql.py
@@ -45,6 +45,12 @@ class PostgresqlDialect(BaseDialect):
     SUPPORTS_PRIMARY_KEY: ClassVar[bool] = True
     SUPPORTS_INDEXES = True
 
+    # https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL
+    # without any precision or scale creates an “unconstrained numeric” column
+    # in which numeric values of any length can be stored, up to the implementation limits.
+    # https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-TABLE
+    DEFAULT_NUMERIC_PRECISION = 16383
+
     TYPE_CLASSES: ClassVar[Dict[str, Type[ColType]]] = {
         # Timestamps
         "timestamp with time zone": TimestampTZ,

--- a/data_diff/databases/vertica.py
+++ b/data_diff/databases/vertica.py
@@ -56,6 +56,9 @@ class Dialect(BaseDialect):
         "boolean": Boolean,
     }
 
+    # https://www.vertica.com/docs/9.3.x/HTML/Content/Authoring/SQLReferenceManual/DataTypes/Numeric/NUMERIC.htm#Default
+    DEFAULT_NUMERIC_PRECISION = 15
+
     def quote(self, s: str):
         return f'"{s}"'
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -134,3 +134,36 @@ class TestThreePartIds(unittest.TestCase):
             d = db.query_table_schema(part.path)
             assert len(d) == 1
             db.query(part.drop())
+
+
+@test_each_database
+class TestNumericPrecisionParsing(unittest.TestCase):
+    def test_specified_precision(self):
+        name = "tbl_" + random_table_suffix()
+        db = get_conn(self.db_cls)
+        tbl = table(name, schema={"value": "NUMERIC(10, 2)"})
+        db.query(tbl.create())
+        t = table(name)
+        raw_schema = db.query_table_schema(t.path)
+        schema = db._process_table_schema(t.path, raw_schema)
+        self.assertEqual(schema["value"].precision,  2)
+
+    def test_specified_zero_precision(self):
+        name = "tbl_" + random_table_suffix()
+        db = get_conn(self.db_cls)
+        tbl = table(name, schema={"value": "NUMERIC(10)"})
+        db.query(tbl.create())
+        t = table(name)
+        raw_schema = db.query_table_schema(t.path)
+        schema = db._process_table_schema(t.path, raw_schema)
+        self.assertEqual(schema["value"].precision, 0)
+
+    def test_default_precision(self):
+        name = "tbl_" + random_table_suffix()
+        db = get_conn(self.db_cls)
+        tbl = table(name, schema={"value": "NUMERIC"})
+        db.query(tbl.create())
+        t = table(name)
+        raw_schema = db.query_table_schema(t.path)
+        schema = db._process_table_schema(t.path, raw_schema)
+        self.assertEqual(schema["value"].precision, db.dialect.DEFAULT_NUMERIC_PRECISION)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -146,7 +146,7 @@ class TestNumericPrecisionParsing(unittest.TestCase):
         t = table(name)
         raw_schema = db.query_table_schema(t.path)
         schema = db._process_table_schema(t.path, raw_schema)
-        self.assertEqual(schema["value"].precision,  2)
+        self.assertEqual(schema["value"].precision, 2)
 
     def test_specified_zero_precision(self):
         name = "tbl_" + random_table_suffix()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -141,7 +141,7 @@ class TestNumericPrecisionParsing(unittest.TestCase):
     def test_specified_precision(self):
         name = "tbl_" + random_table_suffix()
         db = get_conn(self.db_cls)
-        tbl = table(name, schema={"value": "NUMERIC(10, 2)"})
+        tbl = table(name, schema={"value": "DECIMAL(10, 2)"})
         db.query(tbl.create())
         t = table(name)
         raw_schema = db.query_table_schema(t.path)
@@ -151,7 +151,7 @@ class TestNumericPrecisionParsing(unittest.TestCase):
     def test_specified_zero_precision(self):
         name = "tbl_" + random_table_suffix()
         db = get_conn(self.db_cls)
-        tbl = table(name, schema={"value": "NUMERIC(10)"})
+        tbl = table(name, schema={"value": "DECIMAL(10)"})
         db.query(tbl.create())
         t = table(name)
         raw_schema = db.query_table_schema(t.path)
@@ -161,7 +161,7 @@ class TestNumericPrecisionParsing(unittest.TestCase):
     def test_default_precision(self):
         name = "tbl_" + random_table_suffix()
         db = get_conn(self.db_cls)
-        tbl = table(name, schema={"value": "NUMERIC"})
+        tbl = table(name, schema={"value": "DECIMAL"})
         db.query(tbl.create())
         t = table(name)
         raw_schema = db.query_table_schema(t.path)


### PR DESCRIPTION
In Postgres, if type is specified as `NUMERIC` (no scale/precision parameters), the effective scale is 16383 ([docs](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-TABLE)).
In BigQuery, the effective scale in this case is 9 ([community forum](https://www.googlecloudcommunity.com/gc/Databases/What-s-default-Scale-and-Precision-of-Numeric-type-in-BigQuery/m-p/612292#M1281)).