### PR TITLE
Cast to unlimited varchars in MS SQL (especially UUDS)

### DIFF
--- a/data_diff/databases/mssql.py
+++ b/data_diff/databases/mssql.py
@@ -94,7 +94,8 @@ class Dialect(BaseDialect):
         WHERE name = CURRENT_USER"""
 
     def to_string(self, s: str):
-        return f"CONVERT(varchar, {s})"
+        # Both convert(varchar(max), …) and convert(text, …) do work.
+        return f"CONVERT(VARCHAR(MAX), {s})"
 
     def type_repr(self, t) -> str:
         try:


### PR DESCRIPTION
Otherwise, it fails with something like this in tests:

```
    sql_code = 'SELECT min(CONVERT(varchar, [col])), max(CONVERT(varchar, [col])) FROM [src_mssql_uniqueidentifier_postgresql_char100_50_rrp16]'
data_diff.databases.base.QueryError: ('42000', '[42000] [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Insufficient result space to convert uniqueidentifier value to char. (8170) (SQLExecDirectW)')
```

That's because it cannot convert a 36-symbol UUID to 30-symbol varchar. MS SQL Server uses the default length of 30 if other length is not specified.
