### PR TITLE
differences in casing can cause columns to only be excluded from one …

### DIFF
--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -400,6 +400,9 @@ class TableDiffer(ThreadBase, ABC):
         of a table (as per the order of segmentation/bisection). Otherwise,
         that one column might easily hit the limit and stop the whole diff.
         """
+        lowered_column_name1 = column_name1.lower()
+        lowered_column_name2 = column_name2.lower()
+
         with self._ignored_columns_lock:
-            self.ignored_columns1.add(column_name1)
-            self.ignored_columns2.add(column_name2)
+            self.ignored_columns1.add(lowered_column_name1)
+            self.ignored_columns2.add(lowered_column_name2)

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -49,11 +49,11 @@ def diff_sets(
     # TODO update when we add compound keys to hashdiff
     diffs_by_pks: Dict[_PK, List[Tuple[_Op, _Row]]] = defaultdict(list)
     for row in a:
-        cutrow: _Row = tuple(val for col, val in zip(columns1, row) if col not in ignored_columns1)
+        cutrow: _Row = tuple(val for col, val in zip(columns1, row) if col.lower() not in ignored_columns1)
         if cutrow not in sb:
             diffs_by_pks[row[0]].append(("-", row))
     for row in b:
-        cutrow: _Row = tuple(val for col, val in zip(columns2, row) if col not in ignored_columns2)
+        cutrow: _Row = tuple(val for col, val in zip(columns2, row) if col.lower() not in ignored_columns2)
         if cutrow not in sa:
             diffs_by_pks[row[0]].append(("+", row))
 

--- a/data_diff/hashdiff_tables.py
+++ b/data_diff/hashdiff_tables.py
@@ -38,8 +38,12 @@ def diff_sets(
     ignored_columns2: Collection[str],
 ) -> Iterator:
     # Differ only by columns of interest (PKs+relevant-ignored). But yield with ignored ones!
-    sa: Set[_Row] = {tuple(val for col, val in safezip(columns1, row) if col not in ignored_columns1) for row in a}
-    sb: Set[_Row] = {tuple(val for col, val in safezip(columns2, row) if col not in ignored_columns2) for row in b}
+    sa: Set[_Row] = {
+        tuple(val for col, val in safezip(columns1, row) if col.lower() not in ignored_columns1) for row in a
+    }
+    sb: Set[_Row] = {
+        tuple(val for col, val in safezip(columns2, row) if col.lower() not in ignored_columns2) for row in b
+    }
 
     # The first item is always the key (see TableDiffer.relevant_columns)
     # TODO update when we add compound keys to hashdiff

--- a/data_diff/table_segment.py
+++ b/data_diff/table_segment.py
@@ -239,7 +239,7 @@ class TableSegment:
     def count_and_checksum(self) -> Tuple[int, int]:
         """Count and checksum the rows in the segment, in one pass."""
 
-        checked_columns = [c for c in self.relevant_columns if c not in self.ignored_columns]
+        checked_columns = [c for c in self.relevant_columns if c.lower() not in self.ignored_columns]
         cols = [NormalizeAsString(this[c]) for c in checked_columns]
 
         start = time.monotonic()


### PR DESCRIPTION
…side of the diff, causing many exclusive keys