### PR TITLE
Detect duplicate rows on each side

### DIFF
--- a/tests/test_diff_tables.py
+++ b/tests/test_diff_tables.py
@@ -818,11 +818,11 @@ class TestCompoundKeySimple2(DiffTestCase):
         V1 = N + 1
         V2 = N * 1000 + 2
 
-        diffs = [(i, i + N) for i in range(N)]
+        diffs = [(i + 1, i + N) for i in range(N)]  # pk=[1..1000], no dupes
         self.connection.query(
             [
-                self.src_table.insert_rows(diffs + [(K, V1)]),
-                self.dst_table.insert_rows(diffs + [(0, V2)]),
+                self.src_table.insert_rows(diffs + [(K, V1)]),  # exclusive pk=1001
+                self.dst_table.insert_rows(diffs + [(0, V2)]),  # exclusive pk=0
                 commit,
             ]
         )


### PR DESCRIPTION
A known flaw: if there are equal duped rows, e.g.:
```
A: [pk=1000, val=hello], [pk=1000, val=hello]
B: [pk=1000, val=hello], [pk=1000, val=hello]
```

… then we might not notice them even on the level of checksum scanning of table segments. If the segments are fully equal, these dupes will never be yielded, neither with `-/+`, nor with a potentially different informational marker `*` introduced specially for dupes. It will only be noticed in segments that have some other (unrelated) differences. Which makes this dupe-detection not fully reliable.