### PR TITLE
Improve error reporting for PK type mismatch

### DIFF
--- a/data_diff/errors.py
+++ b/data_diff/errors.py
@@ -68,3 +68,7 @@ class DataDiffCloudDiffTimedOut(Exception):
 
 class DataDiffSimpleSelectNotFound(Exception):
     "Raised when using --select on dbt < 1.5 and a model node is not found in the manifest."
+
+
+class DataDiffMismatchingKeyTypesError(Exception):
+    "Raised when the key types of two tables do not match, like VARCHAR and INT."


### PR DESCRIPTION
* Add error type `DataDiffMismatchingKeyTypesError` for diffs with PK columns of different types. 
* Make the error message more clear: show column names instead of internal types representation.