### PR TITLE
Remove UUID-type inference for textual columns

### DIFF
--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -1123,21 +1123,6 @@ class Database(abc.ABC):
         )
         samples_by_col = list(zip(*samples_by_row)) if samples_by_row else [[]] * len(text_columns)
         for col_name, samples in safezip(text_columns, samples_by_col):
-            uuid_samples = [s for s in samples if s and is_uuid(s)]
-
-            if uuid_samples:
-                if len(uuid_samples) != len(samples):
-                    logger.warning(
-                        f"Mixed UUID/Non-UUID values detected in column {'.'.join(table_path)}.{col_name}, disabling UUID support."
-                    )
-                else:
-                    assert col_name in col_dict
-                    col_dict[col_name] = String_UUID(
-                        lowercase=all(s == s.lower() for s in uuid_samples),
-                        uppercase=all(s == s.upper() for s in uuid_samples),
-                    )
-                    continue
-
             if self.SUPPORTS_ALPHANUMS:  # Anything but MySQL (so far)
                 alphanum_samples = [s for s in samples if String_Alphanum.test_value(s)]
                 if alphanum_samples:


### PR DESCRIPTION
We have to be 100% sure that all the values in a textual column are valid UUIDs if we want to treat it as native UUID. Otherwise, the diff may crash when we are converting an invalid UUID to a number. Therefore, inferring the UUID type from a sample is not reliable enough. The PR removes the inference.

Only 1 potential case is affected, when a native UUID column is being compared with a textual column with UUID strings. This won't work out of the box anymore, but it will still be possible with explicit cast in a view. Other cases are covered by alphanumeric PK support.

**Before the change**
| Column A \ Column B  | Native UUID | Text (only UUID) | Text (only alphanum) | Text (arbitrary) |
|----------------------|-------------|------------------|----------------------|------------------|
| Native UUID          | ✅           | ✅ (as UUID)      | ❌                    | ❌                |
| Text (only UUID)     | ✅ (as UUID) | ✅ (as UUID)      | ✅ (as alphanum)      | ❌                |
| Text (only alphanum) | ❌           | ✅ (as alphanum)  | ✅                    | ❌                |
| Text (arbitrary)     | ❌           | ❌                | ❌                    | ❌                |


**After the change**
| Column A \ Column B  | Native UUID                         | Text (only UUID)                    | Text (only alphanum) | Text (arbitrary) |
|----------------------|-------------------------------------|-------------------------------------|----------------------|------------------|
| Native UUID          | ✅                                   | ❌ (but possible with explicit cast) | ❌                    | ❌                |
| Text (only UUID)     | ❌ (but possible with explicit cast) | ✅ (as alphanum)                     | ✅ (as alphanum)      | ❌                |
| Text (only alphanum) | ❌                                   | ✅ (as alphanum)                     | ✅                    | ❌                |
| Text (arbitrary)     | ❌                                   | ❌                                   | ❌                    | ❌                |
