### PR TITLE
update `TRIM` to `LTRIM(RTRIM(...))` for more universal query syntax

### DIFF
--- a/data_diff/databases/base.py
+++ b/data_diff/databases/base.py
@@ -848,7 +848,7 @@ class BaseDialect(abc.ABC):
     def normalize_uuid(self, value: str, coltype: ColType_UUID) -> str:
         """Creates an SQL expression, that strips uuids of artifacts like whitespace."""
         if isinstance(coltype, String_UUID):
-            return f"TRIM({value})"
+            return f"LTRIM(RTRIM({value}))"
         return self.to_string(value)
 
     def normalize_json(self, value: str, _coltype: JSON) -> str:


### PR DESCRIPTION
SQL Server versions before 2017 don't support trim, only ltrim and rtrim. this should be universal across databases. 
referenced in #885 