### PR TITLE
Restrict pydantic dependency to v1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,9 @@ classifiers = [
     "Typing :: Typed"
 ]
 packages = [{ include = "data_diff" }]
+
 [tool.poetry.dependencies]
-pydantic = ">=1.10.12"
+pydantic = ">=1.10.12, <2.0.0"
 python = ">=3.8.0,<4.0"
 dsnparse = "<0.2.0"
 click = ">=8.1"


### PR DESCRIPTION
A fix for https://github.com/datafold/data-diff/issues/869